### PR TITLE
chore: Add issue template for Prisma CLI

### DIFF
--- a/.github/ISSUE_TEMPLATE/prisma-cli-studio-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/prisma-cli-studio-bug-report.md
@@ -1,0 +1,38 @@
+---
+name: Prisma CLI `prisma studio` report
+about: Something not working as expectedwhen using `prisma studio` in Prisma CLI
+title: ''
+labels: 'topic: prisma cli'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
To make Prisma Studio issues a bit more useful, also provide a template for CLI users.