### PR TITLE
fix: align table nav hitboxes with links

### DIFF
--- a/ui/studio/Navigation.test.tsx
+++ b/ui/studio/Navigation.test.tsx
@@ -307,6 +307,29 @@ describe("Navigation", () => {
     darkContainer.remove();
   });
 
+  it("renders table navigation hitboxes on the actual links", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<Navigation />);
+    });
+
+    const tableLink = [
+      ...container.querySelectorAll<HTMLAnchorElement>("a"),
+    ].find((link) => link.textContent?.trim() === "all_data_types");
+
+    expect(tableLink).not.toBeUndefined();
+    expect(tableLink?.getAttribute("data-sidebar")).toBe("menu-button");
+    expect(tableLink?.parentElement?.tagName).toBe("NAV");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
   it("closes table search on blur when the search input is empty", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/ui/studio/Navigation.tsx
+++ b/ui/studio/Navigation.tsx
@@ -2,8 +2,8 @@ import { Slot } from "@radix-ui/react-slot";
 import { Search, Table2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import PrismaLightSymbol from "../../assets/prisma-light-symbol.svg";
 import PrismaLogo from "../../assets/prisma.svg";
+import PrismaLightSymbol from "../../assets/prisma-light-symbol.svg";
 import { Input } from "../components/ui/input";
 import {
   Select,
@@ -18,8 +18,8 @@ import { useNavigation } from "../hooks/use-navigation";
 import { useNavigationTableList } from "../hooks/use-navigation-table-list";
 import { useUiState } from "../hooks/use-ui-state";
 import { cn } from "../lib/utils";
-import { IntrospectionStatusNotice } from "./IntrospectionStatusNotice";
 import { useStudio } from "./context";
+import { IntrospectionStatusNotice } from "./IntrospectionStatusNotice";
 import {
   TABLE_GRID_FOCUS_REQUEST_UI_STATE_KEY,
   TABLE_SEARCH_UI_STATE_KEY,
@@ -486,10 +486,10 @@ const Item = ({
       )}
       {...props}
     >
-      {wrapChildrenInSpan ? (
+      {wrapChildrenInSpan && !asChild ? (
         <span className="truncate">{children}</span>
       ) : (
-        <>{children}</>
+        children
       )}
     </Comp>
   );


### PR DESCRIPTION
## Summary
- move table navigation hitboxes onto the actual anchor elements
- stop wrapping `asChild` nav items in an extra span so hover and cursor state match the clickable area
- add a regression test for table navigation link hitboxes

Fixes #1456