### PR TITLE
fix: preserve postgres stored temporal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Keep PostgreSQL `date` and `timestamp` cells aligned with the stored values by normalizing `postgres.js` results before Studio renders them, so host-local timezones no longer shift table timestamps.
 - Simplify the Compute demo bundling path around `@prisma/dev@0.22.3`, so the deploy build no longer manually copies PGlite runtime assets and plain Bun server bundles no longer need `--packages external`.
 
 ## 0.27.3

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -47,6 +47,11 @@ Table data is shown in a grid with server-backed pagination, filtered-row counts
 The footer keeps page navigation, a page jump field, a fixed rows-per-page dropdown, and infinite-scroll mode in one compact control group, so users can either jump directly to a page, switch page density from a known preset, or turn on lazy-loading without leaving the grid.
 Rows-per-page and infinite-scroll preferences persist across tables through local storage, while the known filtered-row count keeps the footer stable during page transitions for the same filtered result set. Infinite scroll preloads before the hard bottom edge, always appends in fixed 25-row chunks regardless of the paginated page-size setting, keeps filling tall viewports until the grid is actually scrollable, and appends new rows in place without snapping the grid back to the top.
 
+## PostgreSQL Stored Temporal Values
+
+When Studio reads PostgreSQL data through the `postgres.js` executor, `date` and `timestamp without time zone` values are normalized back to their stored wall-clock values before they reach the grid.
+This keeps table cells, copies, and other row-backed UI surfaces from drifting with the host machine timezone, so a stored PostgreSQL timestamp is shown as the value that was actually written.
+
 ## Command Palette
 
 `Cmd/Ctrl+K` opens a compact Studio command palette that immediately focuses search and filters available actions as you type.

--- a/data/postgresjs/index.test.ts
+++ b/data/postgresjs/index.test.ts
@@ -39,7 +39,107 @@ function createPostgresJsMock(args?: {
   };
 }
 
-describe("postgresjs executor sql lint", () => {
+describe("postgresjs executor", () => {
+  it("preserves stored timestamp and date values when postgres.js returns local-time Date objects", async () => {
+    class SimulatedLocalDateValue extends Date {
+      override getDate() {
+        return 1;
+      }
+
+      override getFullYear() {
+        return 2025;
+      }
+
+      override getHours() {
+        return 0;
+      }
+
+      override getMilliseconds() {
+        return 0;
+      }
+
+      override getMinutes() {
+        return 0;
+      }
+
+      override getMonth() {
+        return 0;
+      }
+
+      override getSeconds() {
+        return 0;
+      }
+    }
+
+    class SimulatedLocalTimestampValue extends Date {
+      override getDate() {
+        return 1;
+      }
+
+      override getFullYear() {
+        return 2025;
+      }
+
+      override getHours() {
+        return 0;
+      }
+
+      override getMilliseconds() {
+        return 0;
+      }
+
+      override getMinutes() {
+        return 0;
+      }
+
+      override getMonth() {
+        return 0;
+      }
+
+      override getSeconds() {
+        return 0;
+      }
+    }
+
+    const { postgresjs, unsafe } = createPostgresJsMock();
+    const result = Object.assign(
+      [
+        {
+          date_col: new SimulatedLocalDateValue("2024-12-31T18:00:00.000Z"),
+          id: 1,
+          timestamp_col: new SimulatedLocalTimestampValue(
+            "2024-12-31T18:00:00.000Z",
+          ),
+          timestamptz_col: new Date("2025-01-01T01:00:00.000Z"),
+        },
+      ],
+      {
+        columns: [
+          { name: "id", type: 23 },
+          { name: "date_col", type: 1082 },
+          { name: "timestamp_col", type: 1114 },
+          { name: "timestamptz_col", type: 1184 },
+        ],
+      },
+    );
+
+    unsafe.mockResolvedValue(result);
+
+    const executor = createPostgresJSExecutor(postgresjs);
+    const [error, rows] = await executor.execute({
+      parameters: [],
+      sql: "select 1",
+    });
+
+    expect(error).toBeNull();
+    expect(rows?.[0]).toEqual({
+      date_col: "2025-01-01",
+      id: 1,
+      timestamp_col: "2025-01-01T00:00:00.000Z",
+      timestamptz_col: new Date("2025-01-01T01:00:00.000Z"),
+    });
+  });
+
   it("returns validation diagnostics without touching the database for invalid SQL", async () => {
     const { begin, postgresjs } = createPostgresJsMock();
     const executor = createPostgresJSExecutor(postgresjs);

--- a/data/postgresjs/index.ts
+++ b/data/postgresjs/index.ts
@@ -11,6 +11,12 @@ import type { Query, QueryResult } from "../query";
 const SQL_LINT_STATEMENT_TIMEOUT = "1000ms";
 const SQL_LINT_LOCK_TIMEOUT = "100ms";
 const SQL_LINT_IDLE_IN_TRANSACTION_TIMEOUT = "1000ms";
+const POSTGRES_DATE_OID = 1082;
+const POSTGRES_DATE_ARRAY_OID = 1182;
+const POSTGRES_TIMESTAMP_OID = 1114;
+const POSTGRES_TIMESTAMP_ARRAY_OID = 1115;
+
+type TemporalColumnKind = "date" | "timestamp";
 
 export function createPostgresJSExecutor(postgresjs: Sql): Executor {
   return {
@@ -24,7 +30,7 @@ export function createPostgresJSExecutor(postgresjs: Sql): Executor {
             query.parameters as never,
           );
 
-          return [null, result as never];
+          return [null, normalizeTemporalResult(result as never)];
         } catch (error: unknown) {
           return [error as Error];
         }
@@ -103,7 +109,7 @@ export function createPostgresJSExecutor(postgresjs: Sql): Executor {
 
         connection.release();
 
-        return [null, queryResult as never];
+        return [null, normalizeTemporalResult(queryResult as never)];
       } catch (error: unknown) {
         connection?.release();
 
@@ -253,6 +259,99 @@ export function createPostgresJSExecutor(postgresjs: Sql): Executor {
       }
     },
   };
+}
+
+function normalizeTemporalResult<T>(
+  result: QueryResult<Query<T>>,
+): QueryResult<Query<T>> {
+  const columns = (
+    result as QueryResult<Query<T>> & {
+      columns?: Array<{ name?: string; type?: number }>;
+    }
+  ).columns;
+
+  if (!Array.isArray(columns) || columns.length === 0) {
+    return result;
+  }
+
+  const temporalColumns = columns.flatMap((column) => {
+    const name = column?.name;
+    const kind = getTemporalColumnKind(column?.type);
+
+    if (!name || !kind) {
+      return [];
+    }
+
+    return [{ kind, name }];
+  });
+
+  if (temporalColumns.length === 0) {
+    return result;
+  }
+
+  for (const row of result as Array<Record<string, unknown>>) {
+    for (const { kind, name } of temporalColumns) {
+      row[name] = normalizeTemporalValue(row[name], kind);
+    }
+  }
+
+  return result;
+}
+
+function getTemporalColumnKind(
+  type: number | undefined,
+): TemporalColumnKind | null {
+  if (type === POSTGRES_DATE_OID || type === POSTGRES_DATE_ARRAY_OID) {
+    return "date";
+  }
+
+  if (
+    type === POSTGRES_TIMESTAMP_OID ||
+    type === POSTGRES_TIMESTAMP_ARRAY_OID
+  ) {
+    return "timestamp";
+  }
+
+  return null;
+}
+
+function normalizeTemporalValue(
+  value: unknown,
+  kind: TemporalColumnKind,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeTemporalValue(entry, kind));
+  }
+
+  if (!(value instanceof Date)) {
+    return value;
+  }
+
+  return kind === "date"
+    ? formatStoredDateValue(value)
+    : formatStoredTimestampValue(value);
+}
+
+function formatStoredDateValue(value: Date): string {
+  return [
+    value.getFullYear(),
+    String(value.getMonth() + 1).padStart(2, "0"),
+    String(value.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function formatStoredTimestampValue(value: Date): string {
+  return new Date(
+    Date.UTC(
+      value.getFullYear(),
+      value.getMonth(),
+      value.getDate(),
+      value.getHours(),
+      value.getMinutes(),
+      value.getSeconds(),
+      value.getMilliseconds(),
+    ),
+  ).toISOString();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
## Summary
- normalize `postgres.js` PostgreSQL `date` and `timestamp without time zone` results before Studio renders them
- add a regression test for host-local `Date` parsing shifting stored temporal values
- document the stored-value behavior in `FEATURES.md` and `CHANGELOG.md`

## Testing
- `pnpm vitest --project data data/postgresjs/index.test.ts`
- `pnpm typecheck`
- `./node_modules/.bin/eslint data/postgresjs/index.ts data/postgresjs/index.test.ts`

Fixes #1437