### PR TITLE
Fix schema visualizer overlap and add reset layout

### DIFF
--- a/Architecture/ui-state.md
+++ b/Architecture/ui-state.md
@@ -128,6 +128,9 @@ The following are valid examples of UI state and where they belong:
 - Navigation table-name search term/open state: `uiLocalStateCollection` via `useUiState`
 - Navigation table-selection grid-focus request: `uiLocalStateCollection` via `useUiState`
 - Navigation table-name source rows: `navigationTableNamesCollection`
+- Schema visualizer node positions and layout state: `uiLocalStateCollection` via `useUiState`
+  - Scoped by active schema plus the current visualized table set so returning to the same schema graph restores dragged positions without leaking across schemas.
+  - Includes the stored ELK baseline positions and reset-layout request token used by the header action.
 - Command-palette `x more...` handoff into table browsing: the same navigation table-name search `useUiState` entry, not a second command-palette-specific table-filter store
 
 If new UI state is shared across components, it MUST be assigned to one of these stores (or a new TanStack DB collection added in Studio context).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patch Changes
 
 - Simplify the Compute demo bundling path around `@prisma/dev@0.22.3`, so the deploy build no longer manually copies PGlite runtime assets and plain Bun server bundles no longer need `--packages external`.
+- Auto-arrange the schema visualizer with ELK, space disconnected tables cleanly, and add a `Reset layout` action while keeping dragged node positions when you leave and return.
 
 ## 0.27.3
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -39,6 +39,8 @@ Choosing a filtered table, whether by `Enter` or mouse click, closes the search 
 ## Schema Visualizer
 
 Studio includes a schema graph view with table nodes, column metadata, and detected foreign-key relationships labeled as 1:1 or 1:n.
+The visualizer now runs ELK auto-layout with component-aware spacing so disconnected tables do not collapse into the same visual band, and orthogonal step edges leave clearer corridors between nodes.
+Dragged node positions persist when you leave and return to the same schema view, and a header-level `Reset layout` action re-applies the current ELK baseline when you want to discard manual placement.
 Users can pan/zoom, inspect key and nullable markers, and jump from a node directly to that table’s data view.
 
 ## Data Grid Browsing

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
   },
   "dependencies": {
     "@radix-ui/react-toggle": "1.1.10",
-    "chart.js": "4.5.1"
+    "chart.js": "4.5.1",
+    "elkjs": "0.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   chart.js:
     specifier: 4.5.1
     version: 4.5.1
+  elkjs:
+    specifier: 0.11.1
+    version: 0.11.1
   react:
     specifier: ^18.0.0 || ^19.0.0
     version: 19.2.4
@@ -3713,6 +3716,10 @@ packages:
   /electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
     dev: true
+
+  /elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
+    dev: false
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}

--- a/ui/studio/views/schema/SchemaView.test.tsx
+++ b/ui/studio/views/schema/SchemaView.test.tsx
@@ -3,24 +3,82 @@ import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SchemaVisualizationData } from "../../../hooks/use-schema-visualization";
 import { SchemaView } from "./SchemaView";
 
-const { useSchemaVisualizationMock } = vi.hoisted(() => ({
-  useSchemaVisualizationMock: vi.fn<
-    () => {
-      tables: [];
-      relationships: [];
-    }
-  >(),
+function cloneMockValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+const { uiStateStore, useNavigationMock, useSchemaVisualizationMock } =
+  vi.hoisted(() => ({
+    uiStateStore: new Map<string, unknown>(),
+    useNavigationMock: vi.fn<
+      () => {
+        metadata: {
+          activeSchema: { name: string };
+        };
+      }
+    >(),
+    useSchemaVisualizationMock: vi.fn<() => SchemaVisualizationData>(),
+  }));
+
+vi.mock("@/ui/hooks/use-navigation", () => ({
+  useNavigation: useNavigationMock,
 }));
+
+vi.mock("@/ui/hooks/use-ui-state", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    useUiState: <T,>(key: string, initialValue: T) => {
+      const [value, setValue] = React.useState<T>(() => {
+        if (!uiStateStore.has(key)) {
+          uiStateStore.set(key, cloneMockValue(initialValue));
+        }
+
+        return (
+          (uiStateStore.get(key) as T | undefined) ??
+          cloneMockValue(initialValue)
+        );
+      });
+
+      const setSharedValue = React.useCallback(
+        (updater: T | ((previous: T) => T)) => {
+          setValue((previous) => {
+            const nextValue =
+              typeof updater === "function"
+                ? (updater as (previous: T) => T)(previous)
+                : updater;
+
+            uiStateStore.set(key, cloneMockValue(nextValue));
+            return cloneMockValue(nextValue);
+          });
+        },
+        [key],
+      );
+
+      return [value, setSharedValue] as const;
+    },
+  };
+});
 
 vi.mock("../../../hooks/use-schema-visualization", () => ({
   useSchemaVisualization: useSchemaVisualizationMock,
 }));
 
 vi.mock("../../StudioHeader", () => ({
-  StudioHeader: ({ children }: { children?: ReactNode }) => (
-    <div data-testid="studio-header">{children}</div>
+  StudioHeader: ({
+    children,
+    endContent,
+  }: {
+    children?: ReactNode;
+    endContent?: ReactNode;
+  }) => (
+    <div data-testid="studio-header">
+      <div>{children}</div>
+      <div data-testid="studio-header-end">{endContent}</div>
+    </div>
   ),
 }));
 
@@ -34,6 +92,12 @@ vi.mock("./Visualiser", () => ({
 
 describe("SchemaView", () => {
   beforeEach(() => {
+    uiStateStore.clear();
+    useNavigationMock.mockReturnValue({
+      metadata: {
+        activeSchema: { name: "public" },
+      },
+    });
     useSchemaVisualizationMock.mockReturnValue({
       tables: [],
       relationships: [],
@@ -62,6 +126,71 @@ describe("SchemaView", () => {
     expect(
       legendBadges.every((badge) => badge.className.includes("size-5")),
     ).toBe(true);
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("shows reset layout only after positions diverge from the stored auto layout", () => {
+    useSchemaVisualizationMock.mockReturnValue({
+      tables: [
+        { fields: [], name: "users" },
+        { fields: [], name: "posts" },
+      ],
+      relationships: [],
+    });
+
+    uiStateStore.set("schema-visualizer:public:posts|users:node-positions", {
+      posts: { x: 420, y: 220 },
+      users: { x: 333, y: 444 },
+    });
+    uiStateStore.set(
+      "schema-visualizer:public:posts|users:auto-layout-node-positions",
+      {
+        posts: { x: 420, y: 220 },
+        users: { x: 120, y: 80 },
+      },
+    );
+    uiStateStore.set(
+      "schema-visualizer:public:posts|users:reset-layout-version",
+      0,
+    );
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<SchemaView />);
+    });
+
+    const resetButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Reset layout"),
+    );
+
+    expect(resetButton).toBeTruthy();
+
+    act(() => {
+      resetButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(
+      uiStateStore.get("schema-visualizer:public:posts|users:node-positions"),
+    ).toEqual(
+      uiStateStore.get(
+        "schema-visualizer:public:posts|users:auto-layout-node-positions",
+      ),
+    );
+    expect(
+      uiStateStore.get(
+        "schema-visualizer:public:posts|users:reset-layout-version",
+      ),
+    ).toBe(1);
+    expect(container.textContent).not.toContain("Reset layout");
 
     act(() => {
       root.unmount();

--- a/ui/studio/views/schema/SchemaView.tsx
+++ b/ui/studio/views/schema/SchemaView.tsx
@@ -1,16 +1,70 @@
-import { Key } from "lucide-react";
+import { Key, RotateCcw } from "lucide-react";
+import { useMemo } from "react";
+
+import { Button } from "@/ui/components/ui/button";
+import { useNavigation } from "@/ui/hooks/use-navigation";
+import { useUiState } from "@/ui/hooks/use-ui-state";
 
 import { useSchemaVisualization } from "../../../hooks/use-schema-visualization";
 import { StudioHeader } from "../../StudioHeader";
 import { ViewProps } from "../View";
+import {
+  createSchemaVisualizerStateScope,
+  createSchemaVisualizerUiStateKey,
+  doSchemaNodePositionsDiffer,
+  type SchemaNodePositions,
+} from "./schema-layout";
 import { SchemaVisualization } from "./Visualiser";
 
 export function SchemaView(_props: ViewProps) {
   const { tables, relationships } = useSchemaVisualization();
+  const {
+    metadata: { activeSchema },
+  } = useNavigation();
+  const stateScope = useMemo(
+    () => createSchemaVisualizerStateScope(activeSchema?.name, tables),
+    [activeSchema?.name, tables],
+  );
+  const nodeIds = useMemo(
+    () =>
+      tables
+        .map((table) => table.name)
+        .sort((left, right) => left.localeCompare(right)),
+    [tables],
+  );
+  const [nodePositions, setNodePositions] = useUiState<SchemaNodePositions>(
+    createSchemaVisualizerUiStateKey(stateScope, "node-positions"),
+    {},
+  );
+  const [autoLayoutPositions] = useUiState<SchemaNodePositions>(
+    createSchemaVisualizerUiStateKey(stateScope, "auto-layout-node-positions"),
+    {},
+  );
+  const [, setResetLayoutVersion] = useUiState<number>(
+    createSchemaVisualizerUiStateKey(stateScope, "reset-layout-version"),
+    0,
+  );
+  const isResetLayoutVisible =
+    Object.keys(autoLayoutPositions).length > 0 &&
+    doSchemaNodePositionsDiffer(nodeIds, nodePositions, autoLayoutPositions);
+
+  const resetLayoutButton = isResetLayoutVisible ? (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => {
+        setNodePositions(autoLayoutPositions);
+        setResetLayoutVersion((currentVersion) => currentVersion + 1);
+      }}
+    >
+      <RotateCcw data-icon="inline-start" />
+      Reset layout
+    </Button>
+  ) : null;
 
   return (
     <>
-      <StudioHeader>
+      <StudioHeader endContent={resetLayoutButton}>
         {/* Legend Item: Primary Key */}
         <div className="flex items-center gap-2">
           <span className="flex size-5 items-center justify-center rounded-full bg-muted p-0.5 text-muted-foreground">

--- a/ui/studio/views/schema/Visualiser.test.tsx
+++ b/ui/studio/views/schema/Visualiser.test.tsx
@@ -1,10 +1,47 @@
+import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SchemaVisualization } from "./Visualiser";
 
-const { useNavigationMock } = vi.hoisted(() => ({
+function cloneMockValue<T>(value: T): T {
+  return structuredClone(value);
+}
+
+type ReactFlowNode = {
+  data: {
+    label: string;
+  };
+  id: string;
+  position: {
+    x: number;
+    y: number;
+  };
+};
+
+type ReactFlowProps = {
+  children?: ReactNode;
+  edges: Array<{ id: string; source: string; target: string }>;
+  nodes: ReactFlowNode[];
+  onInit?: (instance: { fitView: () => void }) => void;
+  onNodesChange?: (
+    changes: Array<{
+      id: string;
+      position?: {
+        x: number;
+        y: number;
+      };
+      type: string;
+    }>,
+  ) => void;
+};
+
+const mocks = vi.hoisted(() => ({
+  fitViewMock: vi.fn(),
+  layoutMock: vi.fn(),
+  latestReactFlowProps: null as ReactFlowProps | null,
+  uiStateStore: new Map<string, unknown>(),
   useNavigationMock: vi.fn<
     () => {
       createUrl: () => string;
@@ -16,20 +53,167 @@ const { useNavigationMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("@/ui/hooks/use-navigation", () => ({
-  useNavigation: useNavigationMock,
+  useNavigation: mocks.useNavigationMock,
 }));
+
+vi.mock("@/ui/hooks/use-ui-state", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    useUiState: <T,>(
+      key: string,
+      initialValue: T,
+      options?: { cleanupOnUnmount?: boolean },
+    ) => {
+      const cleanupOnUnmount = options?.cleanupOnUnmount ?? false;
+
+      const [value, setValue] = React.useState<T>(() => {
+        if (!mocks.uiStateStore.has(key)) {
+          mocks.uiStateStore.set(key, cloneMockValue(initialValue));
+        }
+
+        return (
+          (mocks.uiStateStore.get(key) as T | undefined) ??
+          cloneMockValue(initialValue)
+        );
+      });
+
+      React.useEffect(() => {
+        if (cleanupOnUnmount) {
+          return () => {
+            mocks.uiStateStore.delete(key);
+          };
+        }
+
+        return undefined;
+      }, [cleanupOnUnmount, key]);
+
+      const setSharedValue = React.useCallback(
+        (updater: T | ((previous: T) => T)) => {
+          setValue((previous) => {
+            const nextValue =
+              typeof updater === "function"
+                ? (updater as (previous: T) => T)(previous)
+                : updater;
+
+            mocks.uiStateStore.set(key, cloneMockValue(nextValue));
+            return cloneMockValue(nextValue);
+          });
+        },
+        [key],
+      );
+
+      return [value, setSharedValue] as const;
+    },
+  };
+});
+
+vi.mock("elkjs/lib/elk.bundled.js", () => ({
+  default: class MockElk {
+    layout = mocks.layoutMock;
+  },
+}));
+
+vi.mock("reactflow", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  function ReactFlow(props: ReactFlowProps) {
+    mocks.latestReactFlowProps = props;
+
+    React.useEffect(() => {
+      props.onInit?.({ fitView: mocks.fitViewMock });
+    }, [props]);
+
+    return (
+      <div data-testid="reactflow">
+        {props.nodes.map((node) => (
+          <div key={node.id}>{node.data.label}</div>
+        ))}
+        {props.children}
+      </div>
+    );
+  }
+
+  return {
+    __esModule: true,
+    Background: () => null,
+    ConnectionLineType: {
+      SmoothStep: "smoothstep",
+    },
+    Controls: () => null,
+    Handle: () => null,
+    MiniMap: () => null,
+    Position: {
+      Bottom: "bottom",
+      Left: "left",
+      Right: "right",
+      Top: "top",
+    },
+    addEdge: (
+      edge: { id: string; source: string; target: string },
+      edges: Array<{ id: string; source: string; target: string }>,
+    ) => [...edges, edge],
+    applyEdgeChanges: (
+      _changes: unknown[],
+      edges: Array<{ id: string; source: string; target: string }>,
+    ) => edges,
+    applyNodeChanges: (
+      changes: Array<{
+        id: string;
+        position?: {
+          x: number;
+          y: number;
+        };
+        type: string;
+      }>,
+      nodes: ReactFlowNode[],
+    ) =>
+      nodes.map((node) => {
+        const positionChange = changes.find(
+          (change) => change.id === node.id && change.type === "position",
+        );
+
+        if (!positionChange?.position) {
+          return node;
+        }
+
+        return {
+          ...node,
+          position: positionChange.position,
+        };
+      }),
+    default: ReactFlow,
+  };
+});
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 describe("SchemaVisualization", () => {
   beforeEach(() => {
-    useNavigationMock.mockReturnValue({
+    mocks.fitViewMock.mockReset();
+    mocks.layoutMock.mockReset();
+    mocks.latestReactFlowProps = null;
+    mocks.uiStateStore.clear();
+    mocks.useNavigationMock.mockReturnValue({
       createUrl: () => "#",
       metadata: {
         activeSchema: { name: "public" },
       },
+    });
+    mocks.layoutMock.mockResolvedValue({
+      children: [
+        { id: "users", x: 120, y: 80 },
+        { id: "posts", x: 420, y: 220 },
+      ],
     });
   });
 
@@ -38,29 +222,10 @@ describe("SchemaVisualization", () => {
     document.body.innerHTML = "";
   });
 
-  it("renders table nodes and reacts to table list updates", () => {
+  it("applies elk auto-layout positions on first mount", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
-
-    act(() => {
-      root.render(
-        <SchemaVisualization
-          tables={[
-            {
-              name: "users",
-              fields: [{ name: "id", type: "text", isPrimary: true }],
-            },
-          ]}
-          relationships={[]}
-        />,
-      );
-    });
-
-    expect(container.textContent).toContain("users");
-    expect(
-      container.querySelector('[aria-label="Open table users"]'),
-    ).not.toBeNull();
 
     act(() => {
       root.render(
@@ -75,12 +240,27 @@ describe("SchemaVisualization", () => {
               fields: [{ name: "id", type: "text", isPrimary: true }],
             },
           ]}
-          relationships={[{ from: "posts", to: "users", type: "many-to-one" }]}
+          relationships={[{ from: "users", to: "posts", type: "1:n" }]}
         />,
       );
     });
 
-    expect(container.textContent).toContain("posts");
+    await flush();
+
+    expect(mocks.layoutMock).toHaveBeenCalledTimes(1);
+    expect(mocks.latestReactFlowProps?.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "users",
+          position: { x: 0, y: 0 },
+        }),
+        expect.objectContaining({
+          id: "posts",
+          position: { x: 300, y: 140 },
+        }),
+      ]),
+    );
+    expect(mocks.fitViewMock).toHaveBeenCalled();
 
     act(() => {
       root.unmount();
@@ -88,46 +268,65 @@ describe("SchemaVisualization", () => {
     container.remove();
   });
 
-  it("uses semantic foreground colors for table titles and field labels", () => {
+  it("preserves manually adjusted positions across unmounts for the same table set", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
+    const tables = [
+      {
+        name: "users",
+        fields: [{ name: "id", type: "text", isPrimary: true }],
+      },
+      {
+        name: "posts",
+        fields: [{ name: "id", type: "text", isPrimary: true }],
+      },
+    ];
+    const relationships = [{ from: "users", to: "posts", type: "1:n" }];
 
     act(() => {
       root.render(
-        <SchemaVisualization
-          tables={[
-            {
-              name: "users",
-              fields: [
-                { name: "id", type: "text", isPrimary: true },
-                { name: "email", type: "text" },
-              ],
-            },
-          ]}
-          relationships={[]}
-        />,
+        <SchemaVisualization tables={tables} relationships={relationships} />,
       );
     });
 
-    const title = Array.from(container.querySelectorAll("div")).find(
-      (element) =>
-        element.textContent?.trim() === "users" &&
-        element.className.includes("font-semibold"),
-    );
-    const fieldName = Array.from(container.querySelectorAll("span")).find(
-      (element) => element.textContent?.trim() === "email",
-    );
-    const openButton = container.querySelector(
-      '[aria-label="Open table users"]',
-    );
+    await flush();
 
-    expect(title?.parentElement?.className).toContain("text-foreground");
-    expect(fieldName?.parentElement?.className).toContain("text-foreground");
-    expect(openButton?.parentElement?.className).toContain("text-foreground");
+    act(() => {
+      mocks.latestReactFlowProps?.onNodesChange?.([
+        {
+          id: "users",
+          position: { x: 333, y: 444 },
+          type: "position",
+        },
+      ]);
+    });
 
     act(() => {
       root.unmount();
+    });
+
+    const remountRoot = createRoot(container);
+
+    act(() => {
+      remountRoot.render(
+        <SchemaVisualization tables={tables} relationships={relationships} />,
+      );
+    });
+
+    await flush();
+
+    expect(mocks.layoutMock).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.latestReactFlowProps?.nodes.find((node) => node.id === "users"),
+    ).toEqual(
+      expect.objectContaining({
+        position: { x: 333, y: 444 },
+      }),
+    );
+
+    act(() => {
+      remountRoot.unmount();
     });
     container.remove();
   });

--- a/ui/studio/views/schema/Visualiser.tsx
+++ b/ui/studio/views/schema/Visualiser.tsx
@@ -1,23 +1,26 @@
 import { AlertCircle, Key, SquareArrowRight } from "lucide-react";
-import { type FC, JSX, memo, useCallback, useEffect, useMemo } from "react";
+import {
+  type FC,
+  JSX,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import ReactFlow, {
-  addEdge,
-  applyEdgeChanges,
-  applyNodeChanges,
   Background,
-  type Connection,
   ConnectionLineType,
   Controls,
   type Edge,
-  type EdgeChange,
   // EdgeMarker, // TODO: Add EdgeMarkers for relationship type
   Handle,
   MiniMap,
-  type Node,
   type NodeChange,
   type NodeProps,
   type NodeTypes,
   Position,
+  type ReactFlowInstance,
 } from "reactflow";
 
 import { Button } from "@/ui/components/ui/button";
@@ -30,32 +33,29 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "../../../components/ui/tooltip";
+import type {
+  Relationship,
+  Table,
+} from "../../../hooks/use-schema-visualization";
 import { cn } from "../../../lib/utils";
-
-type Field = {
-  name: string;
-  type: string;
-  isPrimary?: boolean;
-  isRequired?: boolean;
-  isNullable?: boolean;
-  isForeignKey?: boolean;
-  foreignKeyTo?: { table: string; column: string };
-};
-
-type Table = {
-  name: string;
-  fields: Field[];
-};
+import {
+  applySchemaNodePositions,
+  createFallbackLayoutedSchemaNodes,
+  createSchemaEdges,
+  createSchemaLayoutSignature,
+  createSchemaNodePositions,
+  createSchemaVisualizerStateScope,
+  createSchemaVisualizerUiStateKey,
+  getAutoLayoutedSchemaNodes,
+  hasSchemaNodePositionsForAllNodes,
+  type SchemaNodeData,
+  type SchemaNodePositions,
+} from "./schema-layout";
 
 type SchemaVisualizationProps = {
   tables: Table[];
-  relationships: { from: string; to: string; type: string }[];
+  relationships: Relationship[];
 };
-
-interface TableNodeData {
-  label: string;
-  fields: Field[];
-}
 
 // Helper component for rendering an icon with a tooltip
 const IconWithTooltip: FC<{
@@ -71,7 +71,7 @@ const IconWithTooltip: FC<{
   </Tooltip>
 );
 
-const TableNode: FC<NodeProps<TableNodeData>> = memo(({ data }) => {
+const TableNode: FC<NodeProps<SchemaNodeData>> = memo(({ data }) => {
   const {
     metadata: { activeSchema },
     createUrl,
@@ -79,7 +79,9 @@ const TableNode: FC<NodeProps<TableNodeData>> = memo(({ data }) => {
   const isNoTablesNode = data.label === "No Tables Found";
 
   // This function now returns an array of icon components to render for a field
-  const getFieldIcons = (field: Field): JSX.Element[] => {
+  const getFieldIcons = (
+    field: SchemaNodeData["fields"][number],
+  ): JSX.Element[] => {
     const icons: JSX.Element[] = [];
 
     // Special case for the "No Tables Found" node message
@@ -141,7 +143,7 @@ const TableNode: FC<NodeProps<TableNodeData>> = memo(({ data }) => {
     <TooltipProvider delayDuration={300}>
       <div
         className={cn(
-          "min-w-[250px] shadow-xl rounded-md border border-border bg-card",
+          "min-w-[280px] shadow-xl rounded-md border border-border bg-card",
           isNoTablesNode && "border-orange-400",
         )}
       >
@@ -228,55 +230,17 @@ const nodeTypes = {
   tableNode: TableNode,
 } as NodeTypes;
 
-/**
- * Create a layout for the nodes with tables placed in a grid formation
- * with related tables placed closer to each other.
- */
-function getLayoutedNodes(
-  tables: Table[],
-  _relationships: { from: string; to: string; type: string }[],
-): Node[] {
-  // If there are only a few tables, use a simple horizontal layout
-  if (tables.length <= 3) {
-    return tables.map((table, index) => ({
-      id: table.name,
-      type: "tableNode",
-      data: {
-        label: table.name,
-        fields: table.fields,
-      },
-      position: { x: 350 * index, y: 50 },
-    }));
-  }
-
-  // For more tables, use a grid layout
-  const GRID_GAP_X = 350;
-  const GRID_GAP_Y = 300;
-  const COLUMNS = Math.ceil(Math.sqrt(tables.length));
-
-  return tables.map((table, index) => {
-    const column = index % COLUMNS;
-    const row = Math.floor(index / COLUMNS);
-
-    return {
-      id: table.name,
-      type: "tableNode",
-      data: {
-        label: table.name,
-        fields: table.fields,
-      },
-      position: {
-        x: column * GRID_GAP_X,
-        y: row * GRID_GAP_Y,
-      },
-    };
-  });
-}
-
 export function SchemaVisualization({
   tables,
   relationships,
 }: SchemaVisualizationProps) {
+  const {
+    metadata: { activeSchema },
+  } = useNavigation();
+  const nodePositionsRef = useRef<SchemaNodePositions>({});
+  const reactFlowInstanceRef = useRef<ReactFlowInstance<SchemaNodeData> | null>(
+    null,
+  );
   // Create a map of node IDs for quick lookup
   const nodeIdSet = useMemo(
     () => new Set(tables.map((table) => table.name)),
@@ -292,95 +256,170 @@ export function SchemaVisualization({
     [relationships, nodeIdSet],
   );
 
-  // Create an organized layout for nodes
-  const initialNodes = useMemo(
-    () => getLayoutedNodes(tables, validRelationships),
-    [tables, validRelationships],
+  const baseNodes = useMemo(
+    () => createFallbackLayoutedSchemaNodes(tables),
+    [tables],
   );
-
-  // Create edges with appropriate styling
   const initialEdges: Edge[] = useMemo(
-    () =>
-      validRelationships.map((rel, index) => ({
-        id: `e${index}`,
-        source: rel.from,
-        target: rel.to,
-        animated: true,
-        label: rel.type,
-        type: "smoothstep",
-        style: {
-          stroke: "var(--primary)",
-          strokeWidth: 1,
-          strokeDasharray: "5 5",
-        },
-        labelStyle: {
-          fill: "var(--primary)",
-          fontSize: 12,
-        },
-      })),
+    () => createSchemaEdges(validRelationships),
     [validRelationships],
   );
 
   const stateScope = useMemo(
-    () =>
-      tables
-        .map((table) => table.name)
-        .sort()
-        .join("|") || "__empty__",
-    [tables],
+    () => createSchemaVisualizerStateScope(activeSchema?.name, tables),
+    [activeSchema?.name, tables],
   );
-
-  const [nodes, setNodes] = useUiState<Node[]>(
-    `schema-visualizer:${stateScope}:nodes`,
-    initialNodes,
-    { cleanupOnUnmount: true },
+  const layoutSignature = useMemo(
+    () => createSchemaLayoutSignature(baseNodes, initialEdges),
+    [baseNodes, initialEdges],
   );
-  const [edges, setEdges] = useUiState<Edge[]>(
-    `schema-visualizer:${stateScope}:edges`,
-    initialEdges,
-    { cleanupOnUnmount: true },
+  const [nodePositions, setNodePositions] = useUiState<SchemaNodePositions>(
+    createSchemaVisualizerUiStateKey(stateScope, "node-positions"),
+    {},
   );
-
-  // Update nodes when tables change
-  useEffect(() => {
-    setNodes(getLayoutedNodes(tables, validRelationships));
-  }, [tables, validRelationships, setNodes]);
-
-  // Update edges when relationships change
-  useEffect(() => {
-    setEdges(
-      validRelationships.map((rel, index) => ({
-        id: `e${index}`,
-        source: rel.from,
-        target: rel.to,
-        animated: true,
-        label: rel.type,
-        type: "smoothstep",
-        style: {
-          stroke: "var(--primary)",
-          strokeWidth: 1,
-          strokeDasharray: "5 5",
-        },
-        labelStyle: {
-          fontSize: 12,
-        },
-      })),
+  const [_autoLayoutPositions, setAutoLayoutPositions] =
+    useUiState<SchemaNodePositions>(
+      createSchemaVisualizerUiStateKey(
+        stateScope,
+        "auto-layout-node-positions",
+      ),
+      {},
     );
-  }, [validRelationships, setEdges]);
+  const [hasAutoLayout, setHasAutoLayout] = useUiState<boolean>(
+    createSchemaVisualizerUiStateKey(stateScope, "has-auto-layout"),
+    false,
+  );
+  const [appliedLayoutSignature, setAppliedLayoutSignature] =
+    useUiState<string>(
+      createSchemaVisualizerUiStateKey(stateScope, "layout-signature"),
+      "",
+    );
+  const [resetLayoutVersion] = useUiState<number>(
+    createSchemaVisualizerUiStateKey(stateScope, "reset-layout-version"),
+    0,
+  );
+  const nodes = useMemo(
+    () => applySchemaNodePositions(baseNodes, nodePositions),
+    [baseNodes, nodePositions],
+  );
+  const previousResetLayoutVersionRef = useRef(resetLayoutVersion);
 
-  const onConnect = useCallback(
-    (params: Edge | Connection) => setEdges((eds) => addEdge(params, eds)),
-    [setEdges],
-  );
+  useEffect(() => {
+    nodePositionsRef.current = nodePositions;
+  }, [nodePositions]);
+
+  const scheduleFitView = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        void reactFlowInstanceRef.current?.fitView({ padding: 0.2 });
+      });
+    });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function syncNodes() {
+      if (
+        hasAutoLayout &&
+        appliedLayoutSignature === layoutSignature &&
+        hasSchemaNodePositionsForAllNodes(baseNodes, nodePositions)
+      ) {
+        return;
+      }
+
+      try {
+        const layoutedNodes = await getAutoLayoutedSchemaNodes(
+          baseNodes,
+          initialEdges,
+        );
+
+        if (cancelled) {
+          return;
+        }
+
+        const nextAutoLayoutPositions =
+          createSchemaNodePositions(layoutedNodes);
+
+        setAutoLayoutPositions(nextAutoLayoutPositions);
+        setNodePositions(nextAutoLayoutPositions);
+      } catch {
+        if (cancelled) {
+          return;
+        }
+
+        const fallbackPositions = createSchemaNodePositions(baseNodes);
+
+        setAutoLayoutPositions(fallbackPositions);
+        setNodePositions(fallbackPositions);
+      }
+
+      setHasAutoLayout(true);
+      setAppliedLayoutSignature(layoutSignature);
+      scheduleFitView();
+    }
+
+    void syncNodes();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    appliedLayoutSignature,
+    baseNodes,
+    hasAutoLayout,
+    initialEdges,
+    layoutSignature,
+    nodePositions,
+    scheduleFitView,
+    setAutoLayoutPositions,
+    setAppliedLayoutSignature,
+    setHasAutoLayout,
+    setNodePositions,
+  ]);
+
+  useEffect(() => {
+    if (previousResetLayoutVersionRef.current === resetLayoutVersion) {
+      return;
+    }
+
+    previousResetLayoutVersionRef.current = resetLayoutVersion;
+    scheduleFitView();
+  }, [resetLayoutVersion, scheduleFitView]);
   const onNodesChange = useCallback(
-    (changes: NodeChange[]) =>
-      setNodes((currentNodes) => applyNodeChanges(changes, currentNodes)),
-    [setNodes],
-  );
-  const onEdgesChange = useCallback(
-    (changes: EdgeChange[]) =>
-      setEdges((currentEdges) => applyEdgeChanges(changes, currentEdges)),
-    [setEdges],
+    (changes: NodeChange[]) => {
+      const nextPositions = Object.fromEntries(
+        changes.flatMap((change) => {
+          if (change.type !== "position" || !change.position) {
+            return [];
+          }
+
+          return [
+            [
+              change.id,
+              {
+                x: change.position.x,
+                y: change.position.y,
+              },
+            ] as const,
+          ];
+        }),
+      );
+
+      if (Object.keys(nextPositions).length === 0) {
+        return;
+      }
+
+      setNodePositions({
+        ...nodePositionsRef.current,
+        ...nextPositions,
+      });
+    },
+    [setNodePositions],
   );
 
   const controlStyles = cn(
@@ -400,11 +439,12 @@ export function SchemaVisualization({
       <div className="w-full h-full bg-card">
         <ReactFlow
           nodes={nodes}
-          edges={edges}
+          edges={initialEdges}
+          onInit={(instance) => {
+            reactFlowInstanceRef.current = instance;
+          }}
           onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          connectionLineType={ConnectionLineType.SmoothStep}
+          connectionLineType={ConnectionLineType.Step}
           nodeTypes={nodeTypes}
           fitView
           fitViewOptions={{ padding: 0.2 }}

--- a/ui/studio/views/schema/schema-layout.test.ts
+++ b/ui/studio/views/schema/schema-layout.test.ts
@@ -1,0 +1,111 @@
+import { Position } from "reactflow";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Table } from "../../../hooks/use-schema-visualization";
+import {
+  doSchemaNodePositionsDiffer,
+  getAutoLayoutedSchemaNodes,
+  type LayoutEngine,
+} from "./schema-layout";
+
+function createTable(name: string, fieldCount: number): Table {
+  return {
+    fields: Array.from({ length: fieldCount }, (_, index) => ({
+      name: `${name}_field_${index}`,
+      type: "text",
+    })),
+    name,
+  };
+}
+
+describe("schema-layout", () => {
+  it("packs disconnected components without overlapping their bounds", async () => {
+    const tables = [
+      createTable("all_data_types", 32),
+      createTable("organizations", 6),
+      createTable("feature_flags", 7),
+      createTable("team_members", 8),
+    ];
+    const baseNodes = tables.map((table) => ({
+      data: {
+        fields: table.fields,
+        label: table.name,
+      },
+      id: table.name,
+      position: { x: 0, y: 0 },
+      sourcePosition: Position.Bottom,
+      targetPosition: Position.Top,
+      type: "tableNode",
+    }));
+    const edges = [
+      {
+        id: "organizations-feature_flags",
+        label: "1:n",
+        source: "organizations",
+        target: "feature_flags",
+      },
+      {
+        id: "organizations-team_members",
+        label: "1:n",
+        source: "organizations",
+        target: "team_members",
+      },
+    ];
+    const layout: LayoutEngine["layout"] = vi
+      .fn()
+      .mockImplementation((graph: Parameters<LayoutEngine["layout"]>[0]) =>
+        Promise.resolve({
+          children:
+            graph.children.length === 1
+              ? [{ id: "all_data_types", x: 0, y: 0 }]
+              : [
+                  { id: "organizations", x: 0, y: 0 },
+                  { id: "feature_flags", x: 0, y: 280 },
+                  { id: "team_members", x: 380, y: 280 },
+                ],
+        }),
+      );
+
+    const nodes = await getAutoLayoutedSchemaNodes(baseNodes, edges, {
+      layout,
+    });
+
+    const allDataTypesNode = nodes.find((node) => node.id === "all_data_types");
+    const organizationsNode = nodes.find((node) => node.id === "organizations");
+
+    expect(allDataTypesNode).toBeDefined();
+    expect(organizationsNode).toBeDefined();
+    expect(layout).toHaveBeenCalledTimes(1);
+    expect(organizationsNode!.position.x).toBeGreaterThanOrEqual(500);
+  });
+
+  it("detects when current positions diverge from the stored auto layout", () => {
+    expect(
+      doSchemaNodePositionsDiffer(
+        ["users", "posts"],
+        {
+          posts: { x: 420, y: 220 },
+          users: { x: 333, y: 444 },
+        },
+        {
+          posts: { x: 420, y: 220 },
+          users: { x: 120, y: 80 },
+        },
+      ),
+    ).toBe(true);
+
+    expect(
+      doSchemaNodePositionsDiffer(
+        ["users", "posts"],
+        {
+          posts: { x: 420, y: 220 },
+          users: { x: 120, y: 80 },
+        },
+        {
+          posts: { x: 420, y: 220 },
+          users: { x: 120, y: 80 },
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/ui/studio/views/schema/schema-layout.ts
+++ b/ui/studio/views/schema/schema-layout.ts
@@ -1,0 +1,523 @@
+import ELK from "elkjs/lib/elk.bundled.js";
+import { type Edge, type Node, Position } from "reactflow";
+
+import type {
+  Field,
+  Relationship,
+  Table,
+} from "../../../hooks/use-schema-visualization";
+
+const elk = new ELK();
+const SCHEMA_VISUALIZER_LAYOUT_VERSION = 2;
+
+const ELK_LAYOUT_OPTIONS = {
+  "elk.algorithm": "layered",
+  "elk.direction": "DOWN",
+  "elk.edgeRouting": "ORTHOGONAL",
+  "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+  "elk.layered.spacing.edgeNodeBetweenLayers": "80",
+  "elk.layered.spacing.nodeNodeBetweenLayers": "180",
+  "elk.spacing.edgeNode": "60",
+  "elk.spacing.nodeNode": "140",
+} as const;
+
+const FALLBACK_GRID_GAP_X = 350;
+const FALLBACK_GRID_GAP_Y = 300;
+const FALLBACK_HORIZONTAL_GAP_X = 350;
+const FALLBACK_HORIZONTAL_START_Y = 50;
+const FALLBACK_MAX_SIMPLE_LAYOUT_TABLES = 3;
+const COMPONENT_GAP_X = 220;
+const COMPONENT_GAP_Y = 180;
+const NODE_WIDTH = 280;
+const NODE_MAX_WIDTH = 360;
+const NODE_HEADER_HEIGHT = 56;
+const NODE_ROW_HEIGHT = 32;
+const NODE_EMPTY_STATE_HEIGHT = 120;
+const NODE_VERTICAL_PADDING = 16;
+const NODE_HORIZONTAL_PADDING = 84;
+const NODE_CHARACTER_WIDTH = 8;
+
+interface ElkGraphChild {
+  height: number;
+  id: string;
+  width: number;
+}
+
+interface ElkGraphEdge {
+  id: string;
+  sources: string[];
+  targets: string[];
+}
+
+interface ElkLayoutGraph {
+  children: ElkGraphChild[];
+  edges: ElkGraphEdge[];
+  id: string;
+  layoutOptions: Record<string, string>;
+}
+
+interface ElkLayoutResultNode {
+  id: string;
+  x?: number;
+  y?: number;
+}
+
+interface ElkLayoutResult {
+  children?: ElkLayoutResultNode[];
+}
+
+export interface SchemaNodeData {
+  fields: Field[];
+  label: string;
+}
+
+export type SchemaNode = Node<SchemaNodeData>;
+export interface SchemaNodePosition {
+  x: number;
+  y: number;
+}
+
+export type SchemaNodePositions = Record<string, SchemaNodePosition>;
+
+export interface LayoutEngine {
+  layout(graph: ElkLayoutGraph): Promise<ElkLayoutResult>;
+}
+
+interface LayoutedSchemaComponent {
+  bounds: {
+    height: number;
+    width: number;
+  };
+  nodes: SchemaNode[];
+}
+
+type SchemaLayoutEdge = Pick<Edge, "id" | "label" | "source" | "target">;
+
+function createSchemaNode(
+  table: Table,
+  position: { x: number; y: number },
+): SchemaNode {
+  return {
+    data: {
+      fields: table.fields,
+      label: table.name,
+    },
+    id: table.name,
+    position,
+    sourcePosition: Position.Bottom,
+    targetPosition: Position.Top,
+    type: "tableNode",
+  };
+}
+
+function estimateNodeHeight(node: SchemaNode): number {
+  if (node.data.label === "No Tables Found") {
+    return NODE_EMPTY_STATE_HEIGHT;
+  }
+
+  return (
+    NODE_HEADER_HEIGHT +
+    node.data.fields.length * NODE_ROW_HEIGHT +
+    NODE_VERTICAL_PADDING
+  );
+}
+
+function estimateNodeWidth(node: SchemaNode): number {
+  const contentWidth = Math.max(
+    node.data.label.length * NODE_CHARACTER_WIDTH + NODE_HORIZONTAL_PADDING,
+    ...node.data.fields.map(
+      (field) =>
+        (field.name.length + field.type.length) * NODE_CHARACTER_WIDTH +
+        NODE_HORIZONTAL_PADDING,
+    ),
+  );
+
+  return Math.max(NODE_WIDTH, Math.min(NODE_MAX_WIDTH, contentWidth));
+}
+
+function getSchemaNodeIds(tables: Pick<Table, "name">[]): string[] {
+  return tables
+    .map((table) => table.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function getSchemaLayoutNodeIds(nodes: Pick<SchemaNode, "id">[]): string[] {
+  return [...nodes]
+    .map((node) => node.id)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function getLayoutComponentBounds(nodes: SchemaNode[]) {
+  const horizontalBounds = nodes.map((node) => ({
+    left: node.position.x,
+    right: node.position.x + estimateNodeWidth(node),
+  }));
+  const verticalBounds = nodes.map((node) => ({
+    bottom: node.position.y + estimateNodeHeight(node),
+    top: node.position.y,
+  }));
+
+  const left = Math.min(...horizontalBounds.map((bound) => bound.left));
+  const right = Math.max(...horizontalBounds.map((bound) => bound.right));
+  const top = Math.min(...verticalBounds.map((bound) => bound.top));
+  const bottom = Math.max(...verticalBounds.map((bound) => bound.bottom));
+
+  return {
+    bottom,
+    height: bottom - top,
+    left,
+    right,
+    top,
+    width: right - left,
+  };
+}
+
+function normalizeLayoutedComponentNodes(
+  nodes: SchemaNode[],
+): LayoutedSchemaComponent {
+  const bounds = getLayoutComponentBounds(nodes);
+
+  return {
+    bounds: {
+      height: bounds.height,
+      width: bounds.width,
+    },
+    nodes: nodes.map((node) => ({
+      ...node,
+      position: {
+        x: node.position.x - bounds.left,
+        y: node.position.y - bounds.top,
+      },
+    })),
+  };
+}
+
+function offsetLayoutedComponentNodes(
+  component: LayoutedSchemaComponent,
+  offset: { x: number; y: number },
+): SchemaNode[] {
+  return component.nodes.map((node) => ({
+    ...node,
+    position: {
+      x: node.position.x + offset.x,
+      y: node.position.y + offset.y,
+    },
+  }));
+}
+
+function splitSchemaLayoutComponents(
+  nodes: SchemaNode[],
+  edges: SchemaLayoutEdge[],
+): Array<{ edges: SchemaLayoutEdge[]; nodes: SchemaNode[] }> {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const adjacency = new Map(
+    nodes.map((node) => [node.id, new Set<string>()] as const),
+  );
+
+  edges.forEach((edge) => {
+    adjacency.get(edge.source)?.add(edge.target);
+    adjacency.get(edge.target)?.add(edge.source);
+  });
+
+  const remainingNodeIds = new Set(nodesById.keys());
+  const components: Array<{ edges: SchemaLayoutEdge[]; nodes: SchemaNode[] }> =
+    [];
+
+  while (remainingNodeIds.size > 0) {
+    const [rootId] = remainingNodeIds;
+
+    if (!rootId) {
+      break;
+    }
+
+    const stack = [rootId];
+    const componentNodeIds = new Set<string>();
+
+    while (stack.length > 0) {
+      const nodeId = stack.pop();
+
+      if (!nodeId || componentNodeIds.has(nodeId)) {
+        continue;
+      }
+
+      componentNodeIds.add(nodeId);
+      remainingNodeIds.delete(nodeId);
+
+      adjacency.get(nodeId)?.forEach((neighborId) => {
+        if (!componentNodeIds.has(neighborId)) {
+          stack.push(neighborId);
+        }
+      });
+    }
+
+    components.push({
+      edges: edges.filter(
+        (edge) =>
+          componentNodeIds.has(edge.source) &&
+          componentNodeIds.has(edge.target),
+      ),
+      nodes: getSchemaLayoutNodeIds(
+        [...componentNodeIds].map((nodeId) => ({ id: nodeId })),
+      )
+        .map((nodeId) => nodesById.get(nodeId))
+        .filter((node): node is SchemaNode => node != null),
+    });
+  }
+
+  return components;
+}
+
+async function getLayoutedSchemaComponent(
+  nodes: SchemaNode[],
+  edges: SchemaLayoutEdge[],
+  layoutEngine: LayoutEngine,
+): Promise<LayoutedSchemaComponent> {
+  if (nodes.length <= 1) {
+    return normalizeLayoutedComponentNodes(
+      nodes.map((node) => ({
+        ...node,
+        position: { x: 0, y: 0 },
+      })),
+    );
+  }
+
+  const layoutedGraph = await layoutEngine.layout({
+    children: nodes.map((node) => ({
+      height: estimateNodeHeight(node),
+      id: node.id,
+      width: estimateNodeWidth(node),
+    })),
+    edges: edges.map((edge) => ({
+      id: edge.id,
+      sources: [edge.source],
+      targets: [edge.target],
+    })),
+    id: "root",
+    layoutOptions: { ...ELK_LAYOUT_OPTIONS },
+  });
+
+  const positionsById = new Map(
+    (layoutedGraph.children ?? []).map((node) => [
+      node.id,
+      {
+        x: node.x ?? 0,
+        y: node.y ?? 0,
+      },
+    ]),
+  );
+
+  return normalizeLayoutedComponentNodes(
+    nodes.map((node) => ({
+      ...node,
+      position: positionsById.get(node.id) ?? node.position,
+    })),
+  );
+}
+
+function packLayoutedSchemaComponents(
+  components: LayoutedSchemaComponent[],
+): SchemaNode[] {
+  if (components.length === 0) {
+    return [];
+  }
+
+  const totalArea = components.reduce(
+    (sum, component) => sum + component.bounds.width * component.bounds.height,
+    0,
+  );
+  const maxComponentWidth = Math.max(
+    ...components.map((component) => component.bounds.width),
+  );
+  const targetRowWidth = Math.max(
+    maxComponentWidth,
+    Math.sqrt(totalArea) * 1.4,
+  );
+
+  let cursorX = 0;
+  let cursorY = 0;
+  let rowHeight = 0;
+
+  return [...components]
+    .sort((left, right) => {
+      const heightDelta = right.bounds.height - left.bounds.height;
+
+      if (heightDelta !== 0) {
+        return heightDelta;
+      }
+
+      return getSchemaLayoutNodeIds(left.nodes)[0]!.localeCompare(
+        getSchemaLayoutNodeIds(right.nodes)[0]!,
+      );
+    })
+    .flatMap((component) => {
+      if (cursorX > 0 && cursorX + component.bounds.width > targetRowWidth) {
+        cursorX = 0;
+        cursorY += rowHeight + COMPONENT_GAP_Y;
+        rowHeight = 0;
+      }
+
+      const offset = { x: cursorX, y: cursorY };
+
+      cursorX += component.bounds.width + COMPONENT_GAP_X;
+      rowHeight = Math.max(rowHeight, component.bounds.height);
+
+      return offsetLayoutedComponentNodes(component, offset);
+    });
+}
+
+export function createFallbackLayoutedSchemaNodes(
+  tables: Table[],
+): SchemaNode[] {
+  if (tables.length <= FALLBACK_MAX_SIMPLE_LAYOUT_TABLES) {
+    return tables.map((table, index) =>
+      createSchemaNode(table, {
+        x: FALLBACK_HORIZONTAL_GAP_X * index,
+        y: FALLBACK_HORIZONTAL_START_Y,
+      }),
+    );
+  }
+
+  const columns = Math.ceil(Math.sqrt(tables.length));
+
+  return tables.map((table, index) => {
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+
+    return createSchemaNode(table, {
+      x: column * FALLBACK_GRID_GAP_X,
+      y: row * FALLBACK_GRID_GAP_Y,
+    });
+  });
+}
+
+export function createSchemaEdges(relationships: Relationship[]): Edge[] {
+  return relationships.map((relationship, index) => ({
+    animated: true,
+    id: `e${index}`,
+    label: relationship.type,
+    labelStyle: {
+      fill: "var(--primary)",
+      fontSize: 12,
+    },
+    source: relationship.from,
+    style: {
+      stroke: "var(--primary)",
+      strokeDasharray: "5 5",
+      strokeWidth: 1,
+    },
+    target: relationship.to,
+    type: "step",
+  }));
+}
+
+export function createSchemaLayoutSignature(
+  nodes: SchemaNode[],
+  edges: Pick<Edge, "label" | "source" | "target">[],
+): string {
+  return JSON.stringify({
+    version: SCHEMA_VISUALIZER_LAYOUT_VERSION,
+    edges: edges
+      .map((edge) => ({
+        label: String(edge.label ?? ""),
+        source: edge.source,
+        target: edge.target,
+      }))
+      .sort((left, right) =>
+        `${left.source}:${left.target}:${left.label}`.localeCompare(
+          `${right.source}:${right.target}:${right.label}`,
+        ),
+      ),
+    nodes: [...nodes]
+      .sort((left, right) => left.id.localeCompare(right.id))
+      .map((node) => ({
+        fieldCount: node.data.fields.length,
+        id: node.id,
+        label: node.data.label,
+      })),
+  });
+}
+
+export function createSchemaVisualizerStateScope(
+  schemaName: string | undefined,
+  tables: Pick<Table, "name">[],
+): string {
+  return `${schemaName ?? "__unknown__"}:${
+    getSchemaNodeIds(tables).join("|") || "__empty__"
+  }`;
+}
+
+export function createSchemaVisualizerUiStateKey(
+  stateScope: string,
+  key: string,
+): string {
+  return `schema-visualizer:${stateScope}:${key}`;
+}
+
+export function createSchemaNodePositions(
+  nodes: Pick<SchemaNode, "id" | "position">[],
+): SchemaNodePositions {
+  return Object.fromEntries(
+    nodes.map((node) => [
+      node.id,
+      {
+        x: node.position.x,
+        y: node.position.y,
+      },
+    ]),
+  );
+}
+
+export function applySchemaNodePositions(
+  nodes: SchemaNode[],
+  positions: SchemaNodePositions,
+): SchemaNode[] {
+  return nodes.map((node) => ({
+    ...node,
+    position: positions[node.id] ?? node.position,
+  }));
+}
+
+export function hasSchemaNodePositionsForAllNodes(
+  nodes: Pick<SchemaNode, "id">[],
+  positions: SchemaNodePositions,
+): boolean {
+  return nodes.every((node) => positions[node.id] != null);
+}
+
+export function doSchemaNodePositionsDiffer(
+  nodeIds: string[],
+  currentPositions: SchemaNodePositions,
+  referencePositions: SchemaNodePositions,
+): boolean {
+  return nodeIds.some((nodeId) => {
+    const currentPosition = currentPositions[nodeId];
+    const referencePosition = referencePositions[nodeId];
+
+    if (!currentPosition || !referencePosition) {
+      return false;
+    }
+
+    return (
+      currentPosition.x !== referencePosition.x ||
+      currentPosition.y !== referencePosition.y
+    );
+  });
+}
+
+export async function getAutoLayoutedSchemaNodes(
+  nodes: SchemaNode[],
+  edges: SchemaLayoutEdge[],
+  layoutEngine: LayoutEngine = elk,
+): Promise<SchemaNode[]> {
+  const layoutedComponents = await Promise.all(
+    splitSchemaLayoutComponents(nodes, edges).map((component) =>
+      getLayoutedSchemaComponent(
+        component.nodes,
+        component.edges,
+        layoutEngine,
+      ),
+    ),
+  );
+
+  return packLayoutedSchemaComponents(layoutedComponents);
+}


### PR DESCRIPTION
## Summary
- improve ELK visualizer spacing and pack disconnected components to avoid overlapping table cards
- switch visualizer edges to clearer orthogonal step routing and persist the ELK baseline separately from dragged positions
- add a header-level `Reset layout` action that appears only after the user moves nodes

## Testing
- pnpm exec eslint ui/studio/views/schema/SchemaView.tsx ui/studio/views/schema/SchemaView.test.tsx ui/studio/views/schema/Visualiser.tsx ui/studio/views/schema/Visualiser.test.tsx ui/studio/views/schema/schema-layout.ts ui/studio/views/schema/schema-layout.test.ts
- pnpm typecheck
- pnpm exec vitest run ui/studio/views/schema/SchemaView.test.tsx ui/studio/views/schema/Visualiser.test.tsx ui/studio/views/schema/schema-layout.test.ts
- Playwright check against the ppg demo on http://localhost:4313

fixes #1455