### PR TITLE
fix: preserve postgres enum array casts on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Fix staged PostgreSQL enum-array edits, so saving a changed `enum[]` cell writes successfully instead of failing on an invalid quoted cast type.
 - Keep PostgreSQL `date` and `timestamp` cells aligned with the stored values by normalizing `postgres.js` results before Studio renders them, so host-local timezones no longer shift table timestamps.
 - Simplify the Compute demo bundling path around `@prisma/dev@0.22.3`, so the deploy build no longer manually copies PGlite runtime assets and plain Bun server bundles no longer need `--packages external`.
 - Auto-arrange the schema visualizer with ELK, space disconnected tables cleanly, and add a `Reset layout` action while keeping dragged node positions when you leave and return.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -148,6 +148,7 @@ Exports can copy directly to the clipboard or save to disk, include column heade
 
 Editable cells open popover editors with datatype-specific controls for raw text, numeric, boolean, enum, JSON/array, date, and time values.
 Save/cancel keyboard behavior is standardized, and null/default/empty semantics are handled explicitly per input type.
+PostgreSQL user-defined enum arrays also persist through that same staged-edit flow, with schema-qualified casts emitted in a form PostgreSQL accepts for `enum[]` writes.
 
 ## Staged Multi-Cell Editing
 

--- a/data/postgres-core/dml.test.ts
+++ b/data/postgres-core/dml.test.ts
@@ -1,5 +1,13 @@
 import { PGlite } from "@electric-sql/pglite";
-import { beforeAll, describe, expect, expectTypeOf, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 
 import type { Table } from "../adapter";
 import type { Executor } from "../executor";
@@ -18,13 +26,14 @@ import {
 describe("postgres-core/dml", () => {
   let executor: Executor;
   let introspection: ReturnType<typeof mockIntrospect>;
+  let pglite: PGlite;
   let table: Table;
 
   beforeAll(async () => {
     vi.useFakeTimers({
       now: new Date("2025-01-27T00:56:12.345+02:00"),
     });
-    const pglite = new PGlite();
+    pglite = new PGlite();
     executor = createPGLiteExecutor(pglite);
     introspection = mockIntrospect();
     table = introspection.schemas.public.tables.users;
@@ -87,7 +96,18 @@ describe("postgres-core/dml", () => {
           '{"status":"triaged"}',
           array['triage','ops']
         );
+        create type "public"."studio_role" as enum ('ADMIN', 'MANAGE', 'VISIT');
+        create table "public"."enum_array_users" (
+          "id" serial primary key,
+          "roles" "public"."studio_role"[] not null default array['VISIT']::"public"."studio_role"[]
+        );
+        insert into "public"."enum_array_users" ("roles")
+        values (array['ADMIN', 'VISIT']::"public"."studio_role"[]);
     `);
+  });
+
+  afterAll(async () => {
+    await pglite.close();
   });
 
   function createSearchTypesTable(): Table {
@@ -317,6 +337,59 @@ describe("postgres-core/dml", () => {
         },
       },
       name: "search_types",
+      schema: "public",
+    };
+  }
+
+  function createEnumArrayUsersTable(): Table {
+    return {
+      columns: {
+        id: {
+          datatype: {
+            group: "numeric",
+            isArray: false,
+            isNative: true,
+            name: "int4",
+            options: [],
+            schema: "pg_catalog",
+          },
+          defaultValue: "nextval('enum_array_users_id_seq'::regclass)",
+          fkColumn: null,
+          fkSchema: null,
+          fkTable: null,
+          isAutoincrement: true,
+          isComputed: false,
+          isRequired: true,
+          name: "id",
+          nullable: false,
+          pkPosition: 1,
+          schema: "public",
+          table: "enum_array_users",
+        },
+        roles: {
+          datatype: {
+            group: "enum",
+            isArray: true,
+            isNative: false,
+            name: "studio_role[]",
+            options: ["ADMIN", "MANAGE", "VISIT"],
+            schema: "public",
+          },
+          defaultValue: `ARRAY['VISIT'::"public"."studio_role"]`,
+          fkColumn: null,
+          fkSchema: null,
+          fkTable: null,
+          isAutoincrement: false,
+          isComputed: false,
+          isRequired: true,
+          name: "roles",
+          nullable: false,
+          pkPosition: null,
+          schema: "public",
+          table: "enum_array_users",
+        },
+      },
+      name: "enum_array_users",
       schema: "public",
     };
   }
@@ -1157,6 +1230,39 @@ describe("postgres-core/dml", () => {
           __ps_updated_at__: "1737932172345",
         },
       ]);
+    });
+
+    it("casts PostgreSQL enum arrays with the array suffix outside the quoted user-defined type name", async () => {
+      const table = createEnumArrayUsersTable();
+      const query = getUpdateQuery({
+        changes: { roles: "{ADMIN,MANAGE}" },
+        row: { id: 1 },
+        table,
+      });
+
+      expect(query).toMatchInlineSnapshot(`
+        {
+          "parameters": [
+            "{ADMIN,MANAGE}",
+            1,
+            1000,
+          ],
+          "sql": "update "public"."enum_array_users" set "roles" = cast($1 as "public"."studio_role"[]) where "id" = $2 returning "id", "roles", cast(floor(extract(epoch from now()) * $3) as text) as "__ps_updated_at__"",
+          "transformations": undefined,
+        }
+      `);
+
+      const [error] = await executor.execute(query);
+
+      expect(error).toBeNull();
+
+      const persisted = await pglite.query<{ roles: string }>(`
+        select "roles"::text as "roles"
+        from "public"."enum_array_users"
+        where "id" = 1
+      `);
+
+      expect(persisted.rows).toEqual([{ roles: "{ADMIN,MANAGE}" }]);
     });
   });
 

--- a/data/query.ts
+++ b/data/query.ts
@@ -29,6 +29,7 @@ import { normalizeSqlWhereClause } from "../lib/sql-filter";
 import type {
   Column,
   ColumnFilter,
+  DataType,
   FilterGroup,
   SqlFilter,
   Table,
@@ -385,10 +386,33 @@ function transformValue(
   }
 
   if (!datatype.isNative) {
-    return eb.cast(eb.val(value), sql.id(datatype.schema, datatype.name));
+    return eb.cast(eb.val(value), getUserDefinedTypeCastTarget(datatype));
   }
 
   return eb.val(value);
+}
+
+function getUserDefinedTypeCastTarget(datatype: DataType): Expression<any> {
+  const { isArray, name, schema } = datatype;
+
+  if (!isArray) {
+    return sql.id(schema, name);
+  }
+
+  const arraySuffixMatch = name.match(/(\[\])+$/);
+
+  if (!arraySuffixMatch) {
+    return sql.id(schema, name);
+  }
+
+  const arraySuffix = arraySuffixMatch[0];
+  const baseName = name.slice(0, -arraySuffix.length);
+
+  if (baseName.length === 0) {
+    return sql.id(schema, name);
+  }
+
+  return sql`${sql.id(schema, baseName)}${sql.raw(arraySuffix)}`;
 }
 
 export function getSelectFilterExpression(


### PR DESCRIPTION
## Summary
- fix PostgreSQL user-defined enum array casts so updates use the valid `"schema"."type"[]` form
- add a regression test that executes an enum-array update against PGlite
- document the fix in FEATURES.md and CHANGELOG.md

## Testing
- pnpm vitest run --project data
- pnpm typecheck
- pnpm exec eslint data/query.ts data/postgres-core/dml.test.ts

fixes #1426