### PR TITLE
Clamp grid cells to the max column width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Keep wide text and JSON columns capped to the grid's existing max width, so oversized cell values clip with an ellipsis instead of blowing the table open.
 - Fix staged PostgreSQL enum-array edits, so saving a changed `enum[]` cell writes successfully instead of failing on an invalid quoted cast type.
 - Keep PostgreSQL `date` and `timestamp` cells aligned with the stored values by normalizing `postgres.js` results before Studio renders them, so host-local timezones no longer shift table timestamps.
 - Simplify the Compute demo bundling path around `@prisma/dev@0.22.3`, so the deploy build no longer manually copies PGlite runtime assets and plain Bun server bundles no longer need `--packages external`.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,7 +66,7 @@ Table navigation stays intentionally short by showing only the first 3 tables by
 Columns support drag-and-drop reordering, resizing, sorting, and pinning to keep important fields anchored during wide-table review.
 Header cells surface model metadata such as primary key, foreign key, required, computed, autoincrement, and datatype.
 Resize handles stay centered on the real column boundary with a forgiving full-height hit target, so resizing does not require pixel-perfect pointer placement.
-Column widths stay bounded to practical defaults, and when users narrow a column the header and cell content clip instead of forcing the column wider than the chosen width.
+Column widths stay bounded to practical defaults, and long text or JSON values respect that same max width by clipping with a standard ellipsis instead of forcing the grid wider than the chosen size.
 Pinning and drag reordering now animate the affected header and visible cells with a short CSS transition, so column layout changes read as motion instead of abrupt jumps. Sticky header layering also keeps the top-left selector corner above the scrolling row-selector column, so the empty spacer cell stays visible while the grid moves underneath it.
 
 ## Inline Table Filters

--- a/ui/studio/cell/WriteableCell.test.tsx
+++ b/ui/studio/cell/WriteableCell.test.tsx
@@ -152,4 +152,46 @@ describe("WriteableCell", () => {
       root.unmount();
     });
   });
+
+  it("keeps the writable display content shrinkable so clipped cells can show an ellipsis", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <table>
+          <tbody>
+            <tr>
+              <WriteableCell
+                cellComponent={<span>Very long organization settings value</span>}
+                inputComponent={<div data-testid="editor-input">editor</div>}
+                isEditorOpen={false}
+                linkComponent={<button type="button">Open relation</button>}
+              />
+            </tr>
+          </tbody>
+        </table>,
+      );
+    });
+
+    const contentRow = container.querySelector("[data-studio-cell-content] > div");
+    if (!(contentRow instanceof HTMLDivElement)) {
+      throw new Error("Could not find writable content row");
+    }
+
+    const textWrapper = contentRow.firstElementChild;
+    if (!(textWrapper instanceof HTMLDivElement)) {
+      throw new Error("Could not find writable text wrapper");
+    }
+
+    expect(contentRow.className).toContain("min-w-0");
+    expect(textWrapper.className).toContain("min-w-0");
+    expect(textWrapper.className).toContain("flex-1");
+    expect(textWrapper.className).toContain("truncate");
+
+    act(() => {
+      root.unmount();
+    });
+  });
 });

--- a/ui/studio/cell/WriteableCell.tsx
+++ b/ui/studio/cell/WriteableCell.tsx
@@ -54,8 +54,8 @@ export function WriteableCell(props: WriteableCellProps) {
   }
 
   const content = (
-    <div className="flex flex-row w-full gap-2 justify-between items-center">
-      <div>{cellComponent}</div>
+    <div className="flex w-full min-w-0 items-center justify-between gap-2">
+      <div className="min-w-0 flex-1 truncate">{cellComponent}</div>
       {linkComponent}
     </div>
   );

--- a/ui/studio/grid/DataGrid.layout.test.tsx
+++ b/ui/studio/grid/DataGrid.layout.test.tsx
@@ -1,0 +1,89 @@
+import type {
+  AccessorKeyColumnDefBase,
+  RowSelectionState,
+} from "@tanstack/react-table";
+import { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DataGrid } from "./DataGrid";
+import { createReadOnlyColumns, type GridRow } from "./test-utils";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.body.innerHTML = "";
+});
+
+function renderGrid(rows: GridRow[]) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  function GridHarness() {
+    const [rowSelectionState, setRowSelectionState] =
+      useState<RowSelectionState>({});
+
+    return (
+      <DataGrid
+        columnDefs={
+          createReadOnlyColumns({
+            includeRowSelector: true,
+            columnIds: ["long_text", "short_text"],
+          }) as AccessorKeyColumnDefBase<Record<string, unknown>>[]
+        }
+        isFetching={false}
+        isProcessing={false}
+        onPaginationChange={vi.fn()}
+        onRowSelectionChange={(updater) => {
+          setRowSelectionState((previous) => {
+            return typeof updater === "function" ? updater(previous) : updater;
+          });
+        }}
+        pageCount={1}
+        paginationState={{ pageIndex: 0, pageSize: 20 }}
+        rows={rows}
+        rowSelectionState={rowSelectionState}
+      />
+    );
+  }
+
+  act(() => {
+    root.render(<GridHarness />);
+  });
+
+  const table = container.querySelector("table");
+  if (!(table instanceof HTMLTableElement)) {
+    throw new Error("Could not find table element");
+  }
+
+  return {
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+    table,
+  };
+}
+
+describe("DataGrid layout", () => {
+  it("pins the table width to the computed column sizes so long content cannot widen columns", () => {
+    const { cleanup, table } = renderGrid([
+      {
+        __ps_rowid: "row_1",
+        long_text: "x".repeat(2_000),
+        short_text: "Acme Labs",
+      },
+    ]);
+
+    expect(table.style.width).toBe("435px");
+    expect(table.style.minWidth).toBe("100%");
+
+    cleanup();
+  });
+});

--- a/ui/studio/grid/DataGrid.tsx
+++ b/ui/studio/grid/DataGrid.tsx
@@ -1187,6 +1187,7 @@ export function DataGrid(props: DataGridProps) {
   });
 
   const centerVisibleLeafColumns = table.getCenterVisibleLeafColumns();
+  const gridTableWidth = `${table.getTotalSize()}px`;
   const leftPinnedWidth = table
     .getLeftVisibleLeafColumns()
     .reduce((total, column) => total + column.getSize(), 0);
@@ -2515,7 +2516,11 @@ export function DataGrid(props: DataGridProps) {
                     tabIndex: 0,
                   }}
                   ref={tableRef}
-                  className="table-fixed border-separate border-spacing-0 box-border w-auto bg-background/50"
+                  className="table-fixed border-separate border-spacing-0 box-border bg-background/50"
+                  style={{
+                    minWidth: "100%",
+                    width: gridTableWidth,
+                  }}
                 >
                   <TableHeader>
                     {getBeforeHeaderRows?.(table)}


### PR DESCRIPTION
## Summary
- enforce the grid table width from the computed column sizes so content cannot blow past the existing max width
- make writable cell content shrink correctly so oversized JSON and text values render with the standard ellipsis
- add regression coverage for both the table layout and writable cell display paths

## Testing
- pnpm vitest ui/studio/cell/WriteableCell.test.tsx ui/studio/grid/DataGrid.layout.test.tsx ui/studio/grid/column-sizing.test.ts ui/studio/grid/DataGrid.virtualization.test.tsx
- pnpm typecheck

fixes #1357