### PR TITLE
Cancel superseded table queries

### DIFF
--- a/Architecture/db-state.md
+++ b/Architecture/db-state.md
@@ -64,6 +64,9 @@ Rows collections MUST be instrumented with TanStack DB mutation guardrails (see 
 Collection `queryFn` MUST call:
 
 - `adapter.query({ table, pageIndex, pageSize, sortOrder, filter }, { abortSignal })`
+- active-table row loading MUST keep only the latest in-flight request authoritative for a given `${schema}.${table}` scope:
+  - starting a new table-row query for the same table MUST abort the previous in-flight request
+  - late completions from superseded requests MUST be ignored, even if the adapter resolves after abort
 
 On success:
 

--- a/Architecture/table-query-controls.md
+++ b/Architecture/table-query-controls.md
@@ -48,6 +48,9 @@ This architecture governs:
 
 Do not mix these responsibilities.
 
+- Applied query-control URL writes MUST use latest-write-wins semantics.
+- Query-control hooks MAY keep transient in-memory pending values while an async URL write is in flight, but those pending values MUST always reflect the most recently requested URL-backed value and MUST clear once the URL state catches up.
+
 ## Filtering Contract
 
 Filtering has two states:
@@ -131,6 +134,7 @@ Rules:
 - Parsing MUST validate `direction` as `asc | desc`.
 - Invalid sort tokens MUST be ignored.
 - Empty sort MUST serialize to `null` URL value.
+- Rapid successive sort changes MUST keep only the latest requested sort authoritative, even if an earlier async URL write resolves later.
 - When staged rows or staged updates exist, sort controls MUST refuse changes until the staged edits are resolved.
 
 Do not store sorting in local component state for table views.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- Keep the latest sort or filter change authoritative by aborting superseded table reads and ignoring older async URL writes, so slow earlier queries can no longer overwrite the visible rows.
 - Keep wide text and JSON columns capped to the grid's existing max width, so oversized cell values clip with an ellipsis instead of blowing the table open.
 - Fix staged PostgreSQL enum-array edits, so saving a changed `enum[]` cell writes successfully instead of failing on an invalid quoted cast type.
 - Keep PostgreSQL `date` and `timestamp` cells aligned with the stored values by normalizing `postgres.js` results before Studio renders them, so host-local timezones no longer shift table timestamps.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -48,6 +48,7 @@ Users can pan/zoom, inspect key and nullable markers, and jump from a node direc
 Table data is shown in a grid with server-backed pagination, filtered-row counts, loading feedback, and explicit empty states.
 The footer keeps page navigation, a page jump field, a fixed rows-per-page dropdown, and infinite-scroll mode in one compact control group, so users can either jump directly to a page, switch page density from a known preset, or turn on lazy-loading without leaving the grid.
 Rows-per-page and infinite-scroll preferences persist across tables through local storage, while the known filtered-row count keeps the footer stable during page transitions for the same filtered result set. Infinite scroll preloads before the hard bottom edge, always appends in fixed 25-row chunks regardless of the paginated page-size setting, keeps filling tall viewports until the grid is actually scrollable, and appends new rows in place without snapping the grid back to the top.
+Rapid sort and filter changes keep the latest request authoritative, and superseded table reads are aborted so a slower older result cannot overwrite the visible grid.
 
 ## PostgreSQL Stored Temporal Values
 

--- a/ui/hooks/use-active-table-rows-collection.test.tsx
+++ b/ui/hooks/use-active-table-rows-collection.test.tsx
@@ -204,6 +204,31 @@ function createRowsCollectionCache() {
   };
 }
 
+function createTableQueryExecutionStateCache() {
+  const cache = new Map<
+    string,
+    { activeController: AbortController | null; latestRequestId: number }
+  >();
+
+  return {
+    getOrCreateTableQueryExecutionState(key: string) {
+      const existing = cache.get(key);
+
+      if (existing != null) {
+        return existing;
+      }
+
+      const created = {
+        activeController: null,
+        latestRequestId: 0,
+      };
+      cache.set(key, created);
+
+      return created;
+    },
+  };
+}
+
 function createTableQueryMetaCollection() {
   return createCollection(
     localOnlyCollectionOptions<TableQueryMetaState>({
@@ -261,10 +286,13 @@ function renderHookHarness(args?: {
   const tableQueryMetaCollection = createTableQueryMetaCollection();
   const queryClient = new QueryClient();
   const { getOrCreateRowsCollection } = createRowsCollectionCache();
+  const { getOrCreateTableQueryExecutionState } =
+    createTableQueryExecutionStateCache();
   const onEvent = vi.fn();
 
   useStudioMock.mockReturnValue({
     adapter,
+    getOrCreateTableQueryExecutionState,
     getOrCreateRowsCollection,
     onEvent,
     queryClient,
@@ -645,6 +673,52 @@ describe("useActiveTableRowsCollection", () => {
 
     await waitFor(() => getLatestState()?.isFetching === false);
     expect(getLatestState()?.filteredRowCount).toBe(52);
+
+    cleanup();
+  });
+
+  it("aborts the superseded in-flight query when the sort order changes", async () => {
+    let queryCalls = 0;
+    let releaseFirstQuery: (() => void) | undefined;
+
+    const { adapter, cleanup, rerender } = renderHookHarness({
+      queryImplementation: async () => {
+        queryCalls += 1;
+
+        if (queryCalls === 1) {
+          await new Promise<void>((resolve) => {
+            releaseFirstQuery = resolve;
+          });
+        }
+
+        return [
+          null,
+          {
+            filteredRowCount: 1,
+            query: {
+              parameters: [],
+              sql: `query-${queryCalls}`,
+            },
+            rows: [{ id: `u${queryCalls}`, name: `User ${queryCalls}` }],
+          },
+        ];
+      },
+    });
+
+    await waitFor(() => (adapter.query as ReturnType<typeof vi.fn>).mock.calls.length === 1);
+
+    const firstQueryOptions = (adapter.query as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
+
+    rerender({
+      sortOrder: [{ column: "name", direction: "desc" }],
+    });
+
+    await waitFor(() => (adapter.query as ReturnType<typeof vi.fn>).mock.calls.length === 2);
+
+    expect(firstQueryOptions?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(firstQueryOptions?.abortSignal.aborted).toBe(true);
+
+    releaseFirstQuery?.();
 
     cleanup();
   });

--- a/ui/hooks/use-active-table-rows-collection.ts
+++ b/ui/hooks/use-active-table-rows-collection.ts
@@ -17,6 +17,7 @@ import type {
   SortOrderItem,
   Table,
 } from "../../data/adapter";
+import { AbortError } from "../../data/executor";
 import { useStudio } from "../studio/context";
 import { useNavigation } from "./use-navigation";
 import { addRowIdToResult } from "./utils/add-row-id-to-result";
@@ -58,6 +59,46 @@ function compareRowsByQueryOrder(left: RowRecord, right: RowRecord): number {
   const rightRowId = String(right.__ps_rowid ?? "");
 
   return leftRowId.localeCompare(rightRowId);
+}
+
+function mergeAbortSignals(signals: Array<AbortSignal | undefined>): {
+  cleanup: () => void;
+  signal: AbortSignal;
+} {
+  const controller = new AbortController();
+  const listeners: Array<{ listener: () => void; signal: AbortSignal }> = [];
+
+  const abort = (signal: AbortSignal) => {
+    if (controller.signal.aborted) {
+      return;
+    }
+
+    controller.abort(signal.reason);
+  };
+
+  for (const signal of signals) {
+    if (!signal) {
+      continue;
+    }
+
+    if (signal.aborted) {
+      abort(signal);
+      continue;
+    }
+
+    const listener = () => abort(signal);
+    signal.addEventListener("abort", listener);
+    listeners.push({ listener, signal });
+  }
+
+  return {
+    cleanup() {
+      for (const { listener, signal } of listeners) {
+        signal.removeEventListener("abort", listener);
+      }
+    },
+    signal: controller.signal,
+  };
 }
 
 export interface ActiveTableRowsCollectionState {
@@ -146,10 +187,19 @@ export function useActiveTableRowsCollection(
 ): ActiveTableRowsCollectionState {
   const { filter, fullTableSearchTerm, pageIndex, pageSize, sortOrder } = query;
   const studio = useStudio();
-  const { adapter, onEvent, queryClient, tableQueryMetaCollection } = studio;
+  const {
+    adapter,
+    getOrCreateTableQueryExecutionState,
+    onEvent,
+    queryClient,
+    tableQueryMetaCollection,
+  } = studio;
   const {
     metadata: { activeTable },
   } = useNavigation();
+  const tableQueryExecutionStateKey = activeTable
+    ? `${activeTable.schema}.${activeTable.name}`
+    : "";
   const sortKey = useMemo(() => getSortKey(sortOrder), [sortOrder]);
   const filterKey = useMemo(
     () => `${getFilterKey(filter)}::${fullTableSearchTerm ?? ""}`,
@@ -347,48 +397,79 @@ export function useActiveTableRowsCollection(
             },
             queryClient,
             queryFn: async ({ signal }) => {
-              const [error, result] = await adapter.query(
-                {
-                  pageIndex,
-                  pageSize,
-                  sortOrder,
-                  table: activeTable,
-                  filter,
-                  fullTableSearchTerm,
-                },
-                { abortSignal: signal },
+              const executionState = getOrCreateTableQueryExecutionState(
+                tableQueryExecutionStateKey,
               );
+              const requestController = new AbortController();
+              const requestId = executionState.latestRequestId + 1;
 
-              if (error) {
+              executionState.latestRequestId = requestId;
+              executionState.activeController?.abort();
+              executionState.activeController = requestController;
+
+              const mergedSignal = mergeAbortSignals([
+                signal,
+                requestController.signal,
+              ]);
+
+              try {
+                const [error, result] = await adapter.query(
+                  {
+                    pageIndex,
+                    pageSize,
+                    sortOrder,
+                    table: activeTable,
+                    filter,
+                    fullTableSearchTerm,
+                  },
+                  { abortSignal: mergedSignal.signal },
+                );
+
+                if (
+                  mergedSignal.signal.aborted ||
+                  requestController.signal.aborted ||
+                  executionState.latestRequestId !== requestId
+                ) {
+                  throw new AbortError();
+                }
+
+                if (error) {
+                  onEvent({
+                    name: "studio_operation_error",
+                    payload: {
+                      operation: "query",
+                      query: error.query,
+                      error,
+                    },
+                  });
+
+                  throw error;
+                }
+
                 onEvent({
-                  name: "studio_operation_error",
+                  name: "studio_operation_success",
                   payload: {
                     operation: "query",
-                    query: error.query,
-                    error,
+                    query: result.query,
+                    error: undefined,
                   },
                 });
 
-                throw error;
+                upsertFilteredRowCount(
+                  filteredRowCountKey,
+                  result.filteredRowCount,
+                  tableQueryMetaCollection,
+                );
+
+                return addRowIdToResult<AdapterQueryResult>(result, activeTable)
+                  .rows;
+              } finally {
+                mergedSignal.cleanup();
+
+                if (executionState.latestRequestId === requestId) {
+                  executionState.activeController = null;
+                }
               }
-
-              onEvent({
-                name: "studio_operation_success",
-                payload: {
-                  operation: "query",
-                  query: result.query,
-                  error: undefined,
-                },
-              });
-
-              upsertFilteredRowCount(
-                filteredRowCountKey,
-                result.filteredRowCount,
-                tableQueryMetaCollection,
-              );
-
-              return addRowIdToResult<AdapterQueryResult>(result, activeTable)
-                .rows;
             },
             queryKey: () => [
               "schema",
@@ -422,10 +503,12 @@ export function useActiveTableRowsCollection(
     pageSize,
     queryClient,
     filteredRowCountKey,
+    getOrCreateTableQueryExecutionState,
     queryScopeKey,
     sortKey,
     sortOrder,
     studio,
+    tableQueryExecutionStateKey,
     tableQueryMetaCollection,
   ]);
 

--- a/ui/hooks/use-filtering.test.tsx
+++ b/ui/hooks/use-filtering.test.tsx
@@ -146,6 +146,12 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
+async function flushMicrotasks(count = 3) {
+  for (let i = 0; i < count; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe("useFiltering", () => {
   it("writes editing filter changes into table UI state", () => {
     const appliedFilter = makeFilter("applied");
@@ -422,6 +428,70 @@ describe("useFiltering", () => {
         kind: "FilterGroup",
       } satisfies FilterGroup),
     );
+
+    cleanup();
+  });
+
+  it("keeps the latest applied filter when an earlier URL write resolves later", async () => {
+    const firstFilter = makeFilter("first");
+    const secondFilter = makeFilter("second");
+    let currentFilterParam = JSON.stringify(defaultFilter);
+    let tableUiState = {
+      editingFilter: firstFilter,
+      id: "public.users",
+      rowSelectionState: {},
+      stagedRows: [],
+    };
+    let releaseFirstFilterWrite: (() => void) | undefined;
+    let filterWriteCallCount = 0;
+    const setFilterParam = vi.fn((value: string) => {
+      filterWriteCallCount += 1;
+      const apply = () => {
+        currentFilterParam = value;
+        return new URLSearchParams();
+      };
+
+      if (filterWriteCallCount === 1) {
+        return new Promise<URLSearchParams>((resolve) => {
+          releaseFirstFilterWrite = () => resolve(apply());
+        });
+      }
+
+      return Promise.resolve().then(apply);
+    });
+
+    useNavigationMock.mockImplementation(() => ({
+      filterParam: currentFilterParam,
+      setFilterParam,
+    }));
+    useTableUiStateMock.mockImplementation(() => ({
+      scopeKey: "public.users",
+      tableUiState,
+      updateTableUiState: vi.fn(
+        (updater: (draft: typeof tableUiState) => void) => {
+          const draft = structuredClone(tableUiState);
+          updater(draft);
+          tableUiState = draft;
+        },
+      ),
+    }));
+
+    const { cleanup, getLatestState } = renderHarness(testColumns);
+
+    await act(async () => {
+      getLatestState()?.setAppliedFilter(firstFilter);
+      await flushMicrotasks();
+      getLatestState()?.setAppliedFilter(secondFilter);
+      await flushMicrotasks();
+    });
+
+    releaseFirstFilterWrite?.();
+
+    await act(async () => {
+      await flushMicrotasks(5);
+    });
+
+    expect(currentFilterParam).toBe(JSON.stringify(secondFilter));
 
     cleanup();
   });

--- a/ui/hooks/use-filtering.ts
+++ b/ui/hooks/use-filtering.ts
@@ -9,6 +9,7 @@ import {
   type EditingFilterGroup,
   mergeEditingFilterUiMetadata,
 } from "./filter-utils";
+import { useLatestAsyncParam } from "./use-latest-async-param";
 import { useNavigation } from "./use-navigation";
 import { useTableUiState } from "./use-table-ui-state";
 
@@ -23,9 +24,16 @@ function parseAppliedFilter(filterParam: string): FilterGroup {
 
 export function useFiltering(columns?: Table["columns"]) {
   const { filterParam, setFilterParam } = useNavigation();
+  const {
+    value: effectiveFilterParam,
+    writeLatestValue: writeLatestFilterParam,
+  } = useLatestAsyncParam({
+    value: filterParam,
+    write: setFilterParam,
+  });
   const appliedFilter = useMemo(
-    () => parseAppliedFilter(filterParam),
-    [filterParam],
+    () => parseAppliedFilter(effectiveFilterParam),
+    [effectiveFilterParam],
   );
   const appliedFilterSerialized = useMemo(
     () => JSON.stringify(appliedFilter),
@@ -36,8 +44,9 @@ export function useFiltering(columns?: Table["columns"]) {
     [appliedFilter],
   );
   const setAppliedFilter = useCallback(
-    (filter: FilterGroup) => void setFilterParam(JSON.stringify(filter)),
-    [setFilterParam],
+    (filter: FilterGroup) =>
+      void writeLatestFilterParam(JSON.stringify(filter)),
+    [writeLatestFilterParam],
   );
   const { scopeKey, tableUiState, updateTableUiState } = useTableUiState({
     editingFilter: editingFilterDefaults,

--- a/ui/hooks/use-latest-async-param.ts
+++ b/ui/hooks/use-latest-async-param.ts
@@ -1,0 +1,74 @@
+import { useCallback, useRef, useState } from "react";
+
+type PendingValue<T> =
+  | {
+      active: false;
+    }
+  | {
+      active: true;
+      value: T;
+    };
+
+const NO_PENDING_VALUE = {
+  active: false,
+} as const;
+
+export function useLatestAsyncParam<T>(args: {
+  value: T;
+  write: (value: T) => Promise<URLSearchParams>;
+}): {
+  value: T;
+  writeLatestValue: (value: T) => Promise<URLSearchParams>;
+} {
+  const { value, write } = args;
+  const [pendingValue, setPendingValue] =
+    useState<PendingValue<T>>(NO_PENDING_VALUE);
+  const writeStateRef = useRef<{
+    hasQueuedWrite: boolean;
+    latestValue: T;
+    pendingPromise: Promise<URLSearchParams> | null;
+  }>({
+    hasQueuedWrite: false,
+    latestValue: value,
+    pendingPromise: null,
+  });
+
+  const writeLatestValue = useCallback(
+    (nextValue: T) => {
+      writeStateRef.current.latestValue = nextValue;
+      writeStateRef.current.hasQueuedWrite = true;
+      setPendingValue({
+        active: true,
+        value: nextValue,
+      });
+
+      if (writeStateRef.current.pendingPromise == null) {
+        writeStateRef.current.pendingPromise = (async () => {
+          try {
+            let params = new URLSearchParams();
+
+            while (writeStateRef.current.hasQueuedWrite) {
+              const valueToWrite = writeStateRef.current.latestValue;
+              writeStateRef.current.hasQueuedWrite = false;
+              params = await write(valueToWrite);
+            }
+
+            return params;
+          } finally {
+            writeStateRef.current.hasQueuedWrite = false;
+            writeStateRef.current.pendingPromise = null;
+            setPendingValue(NO_PENDING_VALUE);
+          }
+        })();
+      }
+
+      return writeStateRef.current.pendingPromise;
+    },
+    [write],
+  );
+
+  return {
+    value: pendingValue.active ? pendingValue.value : value,
+    writeLatestValue,
+  };
+}

--- a/ui/hooks/use-sorting.test.tsx
+++ b/ui/hooks/use-sorting.test.tsx
@@ -230,6 +230,65 @@ describe("useSorting", () => {
     harness.cleanup();
   });
 
+  it("keeps the latest sort request when an earlier URL write resolves later", async () => {
+    let hashParams = new URLSearchParams();
+    let releaseFirstSortWrite: (() => void) | undefined;
+    let sortWriteCallCount = 0;
+
+    const setSortParam = vi.fn((value: string | null) => {
+      sortWriteCallCount += 1;
+      const apply = () => {
+        if (value === null) {
+          hashParams.delete("sort");
+        } else {
+          hashParams.set("sort", value);
+        }
+
+        return new URLSearchParams(hashParams.toString());
+      };
+
+      if (sortWriteCallCount === 1) {
+        return new Promise<URLSearchParams>((resolve) => {
+          releaseFirstSortWrite = () => resolve(apply());
+        });
+      }
+
+      return Promise.resolve().then(apply);
+    });
+    const setPageIndexParam = vi.fn().mockResolvedValue(new URLSearchParams());
+
+    useNavigationMock.mockReturnValue({
+      metadata: { activeTable: undefined },
+      pageIndexParam: "0",
+      setPageIndexParam,
+      setSortParam,
+      sortParam: null,
+    });
+
+    const harness = renderHarness();
+
+    await act(async () => {
+      harness
+        .getLatestState()
+        ?.setSortingState([{ column: "created_at", direction: "asc" }]);
+      await flushMicrotasks();
+      harness
+        .getLatestState()
+        ?.setSortingState([{ column: "created_at", direction: "desc" }]);
+      await flushMicrotasks();
+    });
+
+    releaseFirstSortWrite?.();
+
+    await act(async () => {
+      await flushMicrotasks(5);
+    });
+
+    expect(hashParams.get("sort")).toBe("created_at:desc");
+
+    harness.cleanup();
+  });
+
   it("defaults to ascending sort by single primary key when URL sort is unset", () => {
     useNavigationMock.mockReturnValue({
       metadata: {

--- a/ui/hooks/use-sorting.ts
+++ b/ui/hooks/use-sorting.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from "react";
 
 import type { SortOrderItem, Table } from "../../data/adapter";
+import { useLatestAsyncParam } from "./use-latest-async-param";
 import { useNavigation } from "./use-navigation";
 
 export function useSorting() {
@@ -11,6 +12,13 @@ export function useSorting() {
     sortParam,
     setSortParam,
   } = useNavigation();
+  const {
+    value: effectiveSortParam,
+    writeLatestValue: writeLatestSortParam,
+  } = useLatestAsyncParam({
+    value: sortParam,
+    write: setSortParam,
+  });
 
   // Parse sorting from URL parameter
   const parseSorting = (sortParam: string | null): SortOrderItem[] => {
@@ -35,14 +43,14 @@ export function useSorting() {
   };
 
   const sortingState = useMemo(() => {
-    const parsedSorting = parseSorting(sortParam);
+    const parsedSorting = parseSorting(effectiveSortParam);
 
     if (parsedSorting.length > 0) {
       return parsedSorting;
     }
 
     return getPrimaryKeyDefaultSorting(activeTable);
-  }, [activeTable, sortParam]);
+  }, [activeTable, effectiveSortParam]);
 
   // Update URL when sorting changes from the UI
   const handleSortingChange = useCallback(
@@ -61,14 +69,14 @@ export function useSorting() {
           : null;
 
       void (async () => {
-        await setSortParam(sortString);
+        await writeLatestSortParam(sortString);
 
         if (pageIndexParam !== "0") {
           await setPageIndexParam("0");
         }
       })();
     },
-    [pageIndexParam, setPageIndexParam, setSortParam, sortingState],
+    [pageIndexParam, setPageIndexParam, sortingState, writeLatestSortParam],
   );
 
   return {

--- a/ui/studio/context.tsx
+++ b/ui/studio/context.tsx
@@ -150,6 +150,11 @@ export interface TableQueryMetaState {
   filteredRowCount: number | bigint | NumericString | BigIntString;
 }
 
+export interface TableQueryExecutionState {
+  activeController: AbortController | null;
+  latestRequestId: number;
+}
+
 export interface StudioLocalUiState {
   id: string;
   value: unknown;
@@ -249,6 +254,7 @@ interface StudioContextValue {
     string | number
   >;
   getOrCreateRowsCollection<T>(key: string, factory: () => T): T;
+  getOrCreateTableQueryExecutionState: (key: string) => TableQueryExecutionState;
 }
 
 /**
@@ -275,6 +281,9 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
   const queryClientRef = useRef(new QueryClient());
   const signatureRef = useRef(shortUUID.generate());
   const rowsCollectionCacheRef = useRef(new Map<string, unknown>());
+  const tableQueryExecutionStateCacheRef = useRef(
+    new Map<string, TableQueryExecutionState>(),
+  );
   const lastObservedSystemDarkModeRef = useRef(getSystemDarkMode());
   const studioUiCollectionRef = useRef(
     instrumentTanStackCollectionMutations(
@@ -452,6 +461,23 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
     rowsCollectionCacheRef.current.clear();
   }, []);
 
+  const getOrCreateTableQueryExecutionState = useCallback((key: string) => {
+    const existingState = tableQueryExecutionStateCacheRef.current.get(key);
+
+    if (existingState != null) {
+      return existingState;
+    }
+
+    const nextState: TableQueryExecutionState = {
+      activeController: null,
+      latestRequestId: 0,
+    };
+
+    tableQueryExecutionStateCacheRef.current.set(key, nextState);
+
+    return nextState;
+  }, []);
+
   // Ensure the persisted UI state row exists.
   useEffect(() => {
     if (studioUiCollection.has(STUDIO_UI_STATE_ID)) {
@@ -463,6 +489,11 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
 
   useEffect(() => {
     // if the adapter has been changed, then we need to reload
+    for (const state of tableQueryExecutionStateCacheRef.current.values()) {
+      state.activeController?.abort();
+    }
+
+    tableQueryExecutionStateCacheRef.current.clear();
     clearRowsCollections();
     void queryClient.resetQueries({ exact: false, queryKey: [] });
   }, [adapter, clearRowsCollections, queryClient]);
@@ -762,6 +793,7 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
           sqlEditorStateCollection,
           navigationTableNamesCollection,
           getOrCreateRowsCollection,
+          getOrCreateTableQueryExecutionState,
         }}
       >
         <NuqsHashAdapter>


### PR DESCRIPTION
## Summary
- abort the previous active-table read when sort or filter changes start a newer request
- keep URL-backed sort and filter writes latest-wins so older async updates cannot restore stale controls
- add regression coverage for the race and document the new behavior

## Testing
- pnpm vitest run ui/hooks/use-sorting.test.tsx ui/hooks/use-filtering.test.tsx ui/hooks/use-active-table-rows-collection.test.tsx
- pnpm typecheck

fixes #1320