### PR TITLE
chore: validate actions via PR merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: publish
-# No-op change to validate Actions after enabling them for this repository.
+# No-op change to validate Actions via a PR merge after enabling them for this repository.
 
 on:
   push:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -1,5 +1,5 @@
 name: version packages
-# No-op change to validate Actions after enabling them for this repository.
+# No-op change to validate Actions via a PR merge after enabling them for this repository.
 
 on:
   push:


### PR DESCRIPTION
No-op PR to validate the repository Actions setup through a normal PR merge. This only updates comments in the two workflow files, so merging to main should enqueue both workflows without changing behavior.