### PR TITLE
Add overscroll-x-contain class to Table component

### DIFF
--- a/ui/studio/grid/DataGrid.tsx
+++ b/ui/studio/grid/DataGrid.tsx
@@ -2546,7 +2546,7 @@ export function DataGrid(props: DataGridProps) {
                   containerProps={{
                     "aria-label": "Table grid",
                     className:
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25 overscroll-x-contain",
                     "data-grid-scroll-container": "true",
                     style: {
                       containerType: "inline-size",


### PR DESCRIPTION
this fixes an annoying quirk for trackpads where if you scroll left while it's already at the left edge of the table, it would go back a page.