### PR TITLE
chore: bump happy-dom to a patched release

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "eslint-plugin-unicorn": "55.0.0",
     "eslint-plugin-vitest": "0.5.4",
     "globals": "15.9.0",
-    "happy-dom": "20.7.0",
+    "happy-dom": "20.8.9",
     "kysely": "0.28.10",
     "lucide-react": "0.562.0",
     "motion": "12.27.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ devDependencies:
     specifier: 15.9.0
     version: 15.9.0
   happy-dom:
-    specifier: 20.7.0
-    version: 20.7.0
+    specifier: 20.8.9
+    version: 20.8.9
   kysely:
     specifier: 0.28.10
     version: 0.28.10
@@ -276,7 +276,7 @@ devDependencies:
     version: 1.1.0
   vitest:
     specifier: 4.0.17
-    version: 4.0.17(@types/node@25.0.9)(happy-dom@20.7.0)
+    version: 4.0.17(@types/node@25.0.9)(happy-dom@20.8.9)
   vitest-canvas-mock:
     specifier: 1.1.3
     version: 1.1.3(vitest@4.0.17)
@@ -4418,7 +4418,7 @@ packages:
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.9.3)
       eslint: 8.57.0
-      vitest: 4.0.17(@types/node@25.0.9)(happy-dom@20.7.0)
+      vitest: 4.0.17(@types/node@25.0.9)(happy-dom@20.8.9)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4871,8 +4871,8 @@ packages:
     resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
     dev: true
 
-  /happy-dom@20.7.0:
-    resolution: {integrity: sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==}
+  /happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
     engines: {node: '>=20.0.0'}
     dependencies:
       '@types/node': 25.0.9
@@ -7277,10 +7277,10 @@ packages:
     dependencies:
       cssfontparser: 1.2.1
       moo-color: 1.0.3
-      vitest: 4.0.17(@types/node@25.0.9)(happy-dom@20.7.0)
+      vitest: 4.0.17(@types/node@25.0.9)(happy-dom@20.8.9)
     dev: true
 
-  /vitest@4.0.17(@types/node@25.0.9)(happy-dom@20.7.0):
+  /vitest@4.0.17(@types/node@25.0.9)(happy-dom@20.8.9):
     resolution: {integrity: sha512-FQMeF0DJdWY0iOnbv466n/0BudNdKj1l5jYgl5JVTwjSsZSlqyXFt/9+1sEyhR6CLowbZpV7O1sCHrzBhucKKg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
@@ -7324,7 +7324,7 @@ packages:
       '@vitest/utils': 4.0.17
       es-module-lexer: 1.7.0
       expect-type: 1.3.0
-      happy-dom: 20.7.0
+      happy-dom: 20.8.9
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- bump `happy-dom` from `20.7.0` to `20.8.9`
- refresh the lockfile for the patched release
- keep the existing Vitest UI environment intact

## Context
`happy-dom` is a dev dependency only in this repository. It is used by the Vitest `ui` project as the DOM test environment and is not shipped in the published runtime package.

Closes #1472