### PR TITLE
[codex] Add stable main compute preview

### DIFF
--- a/.changeset/main-compute-preview.md
+++ b/.changeset/main-compute-preview.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": patch
+---
+
+Keep the Compute preview environment for `main` updated whenever the default branch receives new commits.

--- a/.github/workflows/compute-preview.yml
+++ b/.github/workflows/compute-preview.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - reopened
       - synchronize
+  push:
+    branches:
+      - main
   delete:
 
 permissions:
@@ -19,12 +22,14 @@ concurrency:
 
 jobs:
   deploy-preview:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -53,10 +58,11 @@ jobs:
         id: deploy
         env:
           PRISMA_API_TOKEN: ${{ secrets.STUDIO_PREVIEW_COMPUTE_TOKEN }}
-          PREVIEW_BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          PREVIEW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: node scripts/compute-preview/compute-preview-deploy.mjs
 
       - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/Architecture/compute-preview-deploy.md
+++ b/Architecture/compute-preview-deploy.md
@@ -1,11 +1,13 @@
 # Compute Preview Deploys
 
-This document is normative for branch-scoped Compute preview deployments.
+This document is normative for branch-scoped and default-branch Compute preview
+deployments.
 
 ## Purpose
 
-Pull requests need a live Studio preview without manually creating and cleaning up
-Compute services for every branch.
+Pull requests need a live Studio preview without manually creating and cleaning
+up Compute services for every branch. The default branch also needs one stable
+preview that always reflects the latest merged Studio state.
 
 The preview deployment path uses the existing `pnpm build:deploy` artifact and
 publishes it into the dedicated Compute project named `studio-preview`.
@@ -14,17 +16,23 @@ publishes it into the dedicated Compute project named `studio-preview`.
 
 - A preview deploy MUST run when a pull request is opened, reopened, or updated
   with new commits.
+- A stable default-branch preview deploy MUST run when new commits are pushed to
+  `main`.
 - Preview deploys MUST only run for branches inside this repository. Forked pull
   requests MUST NOT receive the Compute token.
 - A preview service MUST be destroyed when the corresponding Git branch is
   deleted.
+- The stable `main` preview service MUST NOT be destroyed by branch-deletion
+  cleanup.
 - Because the GitHub `delete` event is evaluated from the default branch
   workflow set, this workflow MUST be merged to `main` before branch-deletion
   cleanup becomes automatic for later branches.
 
 ## Service Naming
 
-- Preview services MUST be keyed by the pull request branch name.
+- Pull request preview services MUST be keyed by the pull request branch name.
+- The stable default-branch preview service MUST be keyed by the literal
+  `main` ref name.
 - Because Compute service names need a filesystem- and URL-safe shape, the raw
   branch name MUST be normalized to a lowercase slug containing only
   alphanumeric segments separated by `-`.
@@ -49,9 +57,10 @@ publishes it into the dedicated Compute project named `studio-preview`.
 
 ## PR Feedback
 
-- Successful preview deploys MUST post the live service URL back to the pull
-  request.
+- Successful pull request preview deploys MUST post the live service URL back to
+  the pull request.
 - The PR comment MUST be sticky: later deploys for the same PR update the
   existing preview comment instead of creating duplicates.
 - The comment MUST include the original branch name plus the resolved Compute
   service name so any slug normalization stays visible.
+- Default-branch preview deploys MUST NOT post a pull request comment.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,13 +26,16 @@ In that mode the shell hides schema selection, table navigation, and database-on
 Studio's local development workflow can temporarily replace the published npm `@prisma/dev` package with the sibling source package from `../team-expansion/dev/server`, while also swapping its `@prisma/streams-local` dependency over to a built local Streams checkout.
 That override stays opt-in, rebuilds from the sibling repos by default, and can be reverted without rewriting the tracked lockfile, so experimental Prisma Dev and Durable Streams work can stay local to one Studio checkout.
 
-## Compute PR Preview Deploys
+## Compute Preview Deploys
 
 Pull requests can publish the current branch into the dedicated `studio-preview`
 Compute project without hand-creating services for each branch.
 The preview workflow derives a stable Compute-safe service name from the branch,
 reuses that service across later pushes, posts the live URL back to the PR, and
 destroys the preview service when the branch is deleted.
+The same deployment path also keeps one reserved `main` preview service updated
+whenever commits land on the default branch, giving consumers a stable preview of
+the latest merged Studio build.
 
 ## Introspection Recovery and Retry
 

--- a/README.md
+++ b/README.md
@@ -419,18 +419,21 @@ bunx @prisma/compute-cli deploy --skip-build \
 
 ## Compute Preview Deploys
 
-This repo also maintains branch-scoped Compute previews for pull requests.
+This repo maintains branch-scoped Compute previews for pull requests and one
+stable Compute preview for the default branch.
 
 - `.github/workflows/compute-preview.yml` deploys the current PR branch into the
   dedicated `studio-preview` Compute project whenever a PR is opened,
   reopened, or updated with new commits.
+- The same workflow deploys the `main` branch into a reserved `main` Compute
+  service whenever commits are pushed to the default branch.
 - The preview service name is derived from the branch name through a stable
   Compute-safe slug, so later pushes reuse the same service instead of creating
   duplicates.
 - The workflow updates one sticky PR comment with the live preview URL after a
-  successful deploy.
+  successful PR deploy.
 - When a Git branch is deleted, the same workflow destroys the matching preview
-  service.
+  service. The reserved `main` preview is not part of branch-deletion cleanup.
 
 The workflow expects the GitHub Actions secret
 `STUDIO_PREVIEW_COMPUTE_TOKEN`, which should contain a Compute API token for the

--- a/scripts/compute-preview/compute-preview-workflow.test.ts
+++ b/scripts/compute-preview/compute-preview-workflow.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath, URL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const workflowPath = fileURLToPath(
+  new URL("../../.github/workflows/compute-preview.yml", import.meta.url),
+);
+const workflow = readFileSync(workflowPath, "utf8");
+
+describe("compute preview workflow", () => {
+  it("deploys one stable main preview when main receives new commits", () => {
+    expect(workflow).toContain(
+      [
+        "  push:",
+        "    branches:",
+        "      - main",
+      ].join("\n"),
+    );
+    expect(workflow).toContain("github.event_name == 'push'");
+    expect(workflow).toContain("github.ref == 'refs/heads/main'");
+    expect(workflow).toContain(
+      "PREVIEW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}",
+    );
+  });
+
+  it("keeps PR comments and branch cleanup scoped to PR previews", () => {
+    expect(workflow).toContain(
+      [
+        "      - name: Comment preview URL on PR",
+        "        if: github.event_name == 'pull_request'",
+      ].join("\n"),
+    );
+    expect(workflow).toContain(
+      "if: github.event_name == 'delete' && github.event.ref_type == 'branch'",
+    );
+    expect(workflow).toContain(
+      "PREVIEW_BRANCH_NAME: ${{ github.event.ref }}",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Deploy the compute preview workflow on pushes to `main` so a reserved `main` Compute service tracks the latest default branch.
- Keep PR preview comments scoped to pull request deploys while reusing the same deploy helper for PR branches and `main`.
- Document the default-branch preview behavior in the architecture docs, README, FEATURES.md, and add a changeset.

## Validation

- `pnpm vitest --run scripts/compute-preview/compute-preview-utils.test.ts scripts/compute-preview/compute-preview-workflow.test.ts`
- `pnpm typecheck`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/compute-preview.yml`
- `git diff --check`

## Notes

- `pnpm test` was also attempted, but the full suite failed on existing unrelated UI/demo tests and then left a Vitest worker running. The observed failures were in `ui/studio/tanstack-db-performance-architecture.test.ts`, `demo/ppg-dev/build-compute.test.ts`, `ui/studio/CommandPalette.test.tsx`, and `ui/hooks/use-introspection.test.tsx`.
