### PR TITLE
fix mysql introspection json columns

### DIFF
--- a/.changeset/fresh-mice-introspect.md
+++ b/.changeset/fresh-mice-introspect.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": patch
+---
+
+Fix MySQL introspection when JSON aggregated columns are returned as strings.

--- a/data/mysql-core/adapter.ts
+++ b/data/mysql-core/adapter.ts
@@ -1,6 +1,5 @@
 import {
   type Adapter,
-  type AdapterUpdateDetails,
   type AdapterDeleteResult,
   type AdapterError,
   type AdapterInsertResult,
@@ -10,6 +9,7 @@ import {
   type AdapterRequirements,
   type AdapterSqlLintResult,
   type AdapterSqlSchemaResult,
+  type AdapterUpdateDetails,
   type AdapterUpdateManyResult,
   type AdapterUpdateResult,
   type Column,
@@ -599,7 +599,7 @@ function createIntrospection(args: {
       const { schemas } = result;
       const { columns, name: tableName, schema } = table;
 
-      const columnsRecord = columns
+      const columnsRecord = normalizeColumns(columns)
         .sort((a, b) => a.position - b.position)
         .reduce(
           (columns, column) => {
@@ -681,6 +681,26 @@ function createIntrospection(args: {
       timezone,
     } satisfies AdapterIntrospectResult as AdapterIntrospectResult,
   );
+}
+
+function normalizeColumns(
+  columns: QueryResult<typeof getTablesQuery>[number]["columns"],
+): QueryResult<typeof getTablesQuery>[number]["columns"] {
+  if (Array.isArray(columns)) {
+    return columns;
+  }
+
+  if (typeof columns === "string") {
+    const parsedColumns: unknown = JSON.parse(columns);
+
+    if (Array.isArray(parsedColumns)) {
+      return parsedColumns as QueryResult<
+        typeof getTablesQuery
+      >[number]["columns"];
+    }
+  }
+
+  throw new TypeError("Expected MySQL introspection columns to be an array");
 }
 
 const filterOperators = [

--- a/data/mysql-core/introspection-hardening.test.ts
+++ b/data/mysql-core/introspection-hardening.test.ts
@@ -5,6 +5,32 @@ import { createMySQLAdapter } from "./adapter";
 import { mockTablesQuery } from "./introspection";
 
 describe("mysql-core introspection hardening", () => {
+  it("parses JSON string columns returned by MariaDB introspection", async () => {
+    const tables = mockTablesQuery().map((table) => ({
+      ...table,
+      columns: JSON.stringify(table.columns),
+    }));
+    const execute: SequenceExecutor["execute"] = (query) => {
+      if (query.sql.toLowerCase().includes("timezone")) {
+        return Promise.resolve([null, [{ timezone: "UTC" }]] as never);
+      }
+
+      return Promise.resolve([null, tables] as never);
+    };
+    const executor: SequenceExecutor = {
+      execute,
+      executeSequence: vi.fn() as SequenceExecutor["executeSequence"],
+    };
+    const adapter = createMySQLAdapter({ executor });
+
+    const [error, result] = await adapter.introspect({});
+
+    expect(error).toBeNull();
+    expect(
+      result?.schemas.studio?.tables.animals?.columns.id?.isAutoincrement,
+    ).toBe(true);
+  });
+
   it("falls back to UTC when timezone introspection fails", async () => {
     const execute: SequenceExecutor["execute"] = (query) => {
       if (query.sql.toLowerCase().includes("timezone")) {


### PR DESCRIPTION
## Summary

Fix MySQL/MariaDB introspection in Prisma Studio when the introspection query returns aggregated `columns` as a JSON string instead of an array.

This prevents Studio from crashing with errors like:

- `a.sort is not a function`
- `columns.sort is not a function`

## Root cause

Some MySQL-compatible backends (notably MariaDB variants) can return the `json_arrayagg(...)` result as a string payload. The adapter assumed `columns` was always already an array and called `.sort()` directly.

## Fix

- Normalize `columns` before sorting
- Parse JSON string payloads when needed
- Keep the existing behavior unchanged for proper array results
- Add a regression test covering the string-returning case

## Verification

Validated on Node `24.13.0` with:

- `pnpm typecheck`
- `pnpm exec eslint data/mysql-core/adapter.ts data/mysql-core/introspection-hardening.test.ts`
- `pnpm test:data`
- `pnpm build`
- `pnpm check:exports`