### PR TITLE
fix(ui): truncate overflowing SelectTrigger value

### DIFF
--- a/ui/components/ui/select.tsx
+++ b/ui/components/ui/select.tsx
@@ -20,15 +20,15 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between gap-1 whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
   >
-    <div className="flex items-center gap-1">
-      {label && <span className="text-muted-foreground">{label}:</span>}
-      {children}
-    </div>
+    {label && (
+      <span className="shrink-0 text-muted-foreground">{label}:</span>
+    )}
+    <span className="min-w-0 flex-1 truncate text-left">{children}</span>
     <SelectPrimitive.Icon className="flex shrink-0 items-center justify-center opacity-50">
       <ChevronDown className="h-4 w-4" />
     </SelectPrimitive.Icon>


### PR DESCRIPTION
Schema selector overflowed for long names — chevron got pushed out. Flattened the trigger so the value gets `flex-1 min-w-0 truncate` and ellipsizes cleanly.

Before

<img width="900" height="700" alt="01-select-before" src="https://github.com/user-attachments/assets/cf52c1a8-7df2-4e3d-8128-f0cddbad26e6" />

After 
<img width="900" height="700" alt="02-select-after" src="https://github.com/user-attachments/assets/93f948ce-7dbd-4cd5-8bb3-4cfb66ecea55" />
