### PR TITLE
fix(ui): keep readable text contrast on Discard edits hover

### DIFF
--- a/ui/studio/views/table/ActiveTableView.tsx
+++ b/ui/studio/views/table/ActiveTableView.tsx
@@ -1695,9 +1695,8 @@ export function ActiveTableView(_props: ViewProps) {
                   ? `${discardWiggleAnimationKey}-${discardWiggleCount}`
                   : undefined
               }
-              variant="outline"
               className={cn(
-                "h-9 border-amber-300 bg-amber-100 px-4 font-sans text-amber-950 hover:border-amber-400 hover:bg-amber-200 motion-safe:origin-center motion-safe:will-change-transform",
+                "h-9 border border-amber-300 bg-amber-100 px-4 font-sans text-amber-950 hover:border-amber-400 hover:bg-amber-200 motion-safe:origin-center motion-safe:will-change-transform",
                 discardWiggleAnimationClassName,
               )}
               onClick={() => setDiscardDialogOpen(true)}


### PR DESCRIPTION
`variant="outline"` injected `hover:text-accent-foreground`, which the local className didn't override — text turned light over amber on hover. Dropped the variant and added `border` explicitly to match the sibling Save edits button.


Before
<img width="320" height="80" alt="03-discard-before" src="https://github.com/user-attachments/assets/e056990d-e5c9-44c9-b804-12428988e98f" />


after

<img width="320" height="80" alt="04-discard-after" src="https://github.com/user-attachments/assets/ff84cd43-115b-4cfb-88a5-1691f7e960f4" />

