### PR TITLE
Add Query Insights Studio view

### DIFF
--- a/.changeset/query-insights-studio-port.md
+++ b/.changeset/query-insights-studio-port.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": minor
+---
+
+Add the host-provided Query Insights Studio view with live `prisma-log` stream ingestion, ppg-dev demo support, charted query metrics, sortable query rows, and AI recommendation details.

--- a/Architecture/demo-compute-bundling.md
+++ b/Architecture/demo-compute-bundling.md
@@ -35,7 +35,7 @@ That means when `build-compute.ts` bundles `demo/ppg-dev/server.ts` with Bun:
 
 - Bun sees `@prisma/dev`'s literal Bun manifest import
 - Bun emits hashed PGlite `.wasm`, `.data`, and extension archives next to the bundled server entrypoint
-- `build-compute.ts` then copies the same runtime assets into `deploy/bundle/` with their canonical names like `pglite.wasm` and `pglite-seed.tar.gz`
+- `build-compute.ts` then copies the same runtime assets into `deploy/bundle/` with their canonical names like `pglite.wasm`, `pglite.data`, `initdb.wasm`, and extension archives
 
 That extra copy is a Studio-side workaround for the current Compute boot path:
 the deployed `@prisma/dev` runtime still resolves stable filenames relative to

--- a/Architecture/navigation-url-state.md
+++ b/Architecture/navigation-url-state.md
@@ -8,7 +8,7 @@ Navigation state MUST be URL-driven and managed through `useNavigation` + Nuqs. 
 
 This architecture governs:
 
-- active Studio view (`table`, `schema`, `console`, `sql`, `stream`)
+- active Studio view (`table`, `schema`, `console`, `sql`, `stream`, `query-insights`)
 - active schema/table/stream
 - active stream follow mode
 - active stream aggregation-panel visibility
@@ -47,6 +47,8 @@ Only keys declared in [`ui/hooks/nuqs.ts`](../ui/hooks/nuqs.ts) are allowed:
 - `filter`
 - `sort`
 - `pin`
+- `queryInsightsSort`
+- `queryInsightsTable`
 - `pageIndex`
 - `pageSize`
 - `search`
@@ -58,6 +60,8 @@ Notes:
 - `searchScope` is legacy URL state and is not used for table-name navigation filtering.
 - `pin` stores left-pinned data columns for the grid as a comma-separated list (for example `pin=id,bigint_col`).
 - `pin` order is authoritative and MUST be updated when users drag-reorder pinned columns.
+- `queryInsightsSort` stores Query Insights sort state as `<field>:<direction>`.
+- `queryInsightsTable` stores the active Query Insights table-name filter.
 - `pageIndex` remains URL-backed for table navigation.
 - `pageSize` remains a supported hash key for compatibility, but table rendering now takes its authoritative rows-per-page preference from `studioUiCollection.tablePageSize` in [`Architecture/ui-state.md`](ui-state.md).
 - `streamFollow` stores the active stream follow mode (`paused`, `live`, or `tail`).
@@ -82,11 +86,14 @@ Adding a new URL key requires updating `StateKey` in `nuqs.ts` first.
 - `streamFollow`: no global default in `useNavigation`; the active stream view MUST resolve an absent value to `tail` and materialize that into the hash
 - `aggregations`: no global default in `useNavigation`; the active stream view MUST treat an absent flag as closed and MUST NOT materialize that closed state into the hash
 - `streamAggregationRange`: no standalone default; the active stream view MUST clear it whenever `aggregations` is absent, and MUST materialize its default range only after the aggregation panel is opened
+- `queryInsightsSort`: no global default in `useNavigation`; the Query Insights view resolves an absent or invalid value to `reads:desc`
+- `queryInsightsTable`: no global default in `useNavigation`; absent means all observed tables
 
 When Studio is running without a database connection but with Streams enabled:
 
 - the resolved default `view` MUST become `"stream"` instead of `"table"`
 - stale database-oriented views such as `table`, `schema`, `console`, and `sql` MUST resolve back to the stream view instead of trying to render database-only UI against a disabled database session
+- stale `query-insights` URLs MUST resolve back to the default view when the host did not provide a Query Insights transport
 
 When URL params are stale from a previous DB, invalid `schema`/`table` values MUST be resolved to valid current defaults.
 Shared table page size and infinite-scroll mode are not derived from URL defaults; they are restored through Studio UI state and then mirrored into query behavior by `usePagination`.

--- a/Architecture/non-standard-ui.md
+++ b/Architecture/non-standard-ui.md
@@ -145,6 +145,26 @@ It deliberately excludes:
   - The storage breakdowns also need collapsible ledger-style accounting boxes whose headers surface the section totals when folded shut, plus faint shared-cap annotations that sit beside right-aligned byte values and one shared cap marker spanning both Routing and Exact cache rows, which is not a stock ShadCN pattern.
   - No stock ShadCN pattern covers that descriptor-driven observability layout, especially when the UI must distinguish logical bytes from physical storage signals, separate search coverage from historical run indexes, hide unconfigured routing rows, and keep the remaining cost caveats explicit instead of inventing unavailable totals.
 
+### Query Insights Live Observability View
+
+- Canonical components:
+  - [`ui/studio/views/query-insights/QueryInsightsView.tsx`](../ui/studio/views/query-insights/QueryInsightsView.tsx)
+  - [`ui/studio/views/query-insights/QueryInsightsChart.tsx`](../ui/studio/views/query-insights/QueryInsightsChart.tsx)
+- Closest standard ShadCN alternatives:
+  - `Card`
+  - `Table`
+  - `Sheet`
+- Why it stays non-standard:
+  - Query Insights needs a bounded live SSE session, chart ticks that update independently from table pause state, row grouping by Prisma operation, pause-buffer flushing highlights, and previous/next navigation inside a detail sheet.
+  - No stock ShadCN block covers that observability-specific control model, so Studio composes the surface from standard primitives while keeping the stream, chart, and row-state behavior local to this view.
+- Required internals:
+  - `Badge`
+  - `Button`
+  - `Card`
+  - `Select`
+  - `Sheet`
+  - `Table`
+
 ## Standardization Candidates
 
 These are the current high-signal places where Studio is bypassing a plausible standard ShadCN component or composition pattern.

--- a/Architecture/query-insights.md
+++ b/Architecture/query-insights.md
@@ -73,7 +73,7 @@ Selecting a row auto-pauses table updates. Closing a sheet that caused auto-paus
 
 Studio's `Query` contract includes `meta.visibility`.
 
-Postgres adapter-generated introspection, table reads, mutations, and fallback lint helper queries MUST be marked `studio-system`. Raw SQL editor executions remain user-visible. BFF hosts should append `-- prisma:studio` to system queries before forwarding them to the database so backend Query Insights implementations can filter them consistently with `-- prisma:console`.
+Postgres adapter-generated introspection, table reads, mutations, and fallback lint helper queries MUST be marked `studio-system`. Raw SQL editor executions remain user-visible. BFF hosts should append `-- prisma:studio` to system queries before forwarding them to the database so backend Query Insights implementations can classify them consistently with `-- prisma:console`. System classification MUST NOT prevent successful query executions from being appended to `prisma-log`.
 
 ## ppg-dev Demo
 
@@ -82,7 +82,7 @@ The local `ppg-dev` demo hosts the Query Insights backend itself:
 - `/api/config` advertises the Query Insights transport URLs
 - ppg-dev ensures the `prisma-log` stream exists on the configured Prisma
   Streams server at startup
-- `/api/query` appends the Studio system suffix to system queries, executes the database request, and appends each successful user-visible SQL execution to `prisma-log`
+- `/api/query` appends the Studio system suffix to system queries, executes the database request, and appends each successful SQL execution to `prisma-log` with query visibility metadata
 - the Query Insights UI reads from `/api/streams/v1/stream/prisma-log`, so it
   uses the same same-origin Streams proxy as the Stream view
 - `/api/query-insights/analyze` returns deterministic demo analysis

--- a/Architecture/query-insights.md
+++ b/Architecture/query-insights.md
@@ -43,9 +43,11 @@ The canonical Query Insights data source is a Prisma Streams JSON stream named
 continuously by the host while queries execute, regardless of whether the Query
 Insights view is currently open.
 
-The Studio UI reads that stream through the normal Streams HTTP surface, using
-`GET /v1/stream/prisma-log?format=json&offset=-1&live=sse`. This means the UI
-receives standard Streams SSE events:
+The Studio UI reads that stream through the normal Streams HTTP surface. On
+mount, it first performs a non-live snapshot read from the same stream URL so
+already-recorded queries populate the view. It then opens the live SSE URL from
+the returned `Stream-Next-Offset` cursor so new appends continue streaming
+without replay gaps. The live connection receives standard Streams SSE events:
 
 - `data`: a JSON array of `prisma-log` events
 - `control`: stream cursor and up-to-date metadata, currently ignored by Query

--- a/Architecture/query-insights.md
+++ b/Architecture/query-insights.md
@@ -1,0 +1,91 @@
+# Query Insights Architecture
+
+This document is normative for Studio's Query Insights view (`view=query-insights`).
+
+Query Insights is an optional host-provided observability surface. Studio core owns the UI, URL state, stream decoding, bounded in-browser session state, charts, table controls, and detail sheet. The host owns the backend stream, authorization, tenant or demo database lookup, and structured analysis endpoint.
+
+## Studio Boundary
+
+Studio receives Query Insights through `StudioProps.queryInsights`.
+
+The transport provides:
+
+- initial AI recommendation consent state
+- an SSE `streamUrl` that reads a JSON `prisma-log` Prisma Streams stream
+- a structured `analyze(input)` function
+- an `enableAiRecommendations()` function
+- optional UI event forwarding
+
+When the transport is absent, Studio MUST hide the sidebar item and command-palette action. A stale `#view=query-insights` URL MUST resolve back to the normal default view.
+
+## URL State
+
+Query Insights uses Studio's normal hash navigation state:
+
+- `view=query-insights`
+- `queryInsightsSort=<latency|reads|executions|lastSeen>:<asc|desc>`
+- `queryInsightsTable=<table name>`
+
+All reads and writes MUST go through `useNavigation`.
+
+## Runtime State
+
+Query Insights rows are intentionally local React state rather than TanStack DB collections.
+
+This is a documented exception to the database-state architecture because Query Insights data is not table data, has no persistence contract, resets per stream session, and is bounded to 500 unique query patterns plus a 500-row paused buffer. Chart points are also local and capped to 100 points.
+
+The stream MUST only be opened while the Query Insights view is mounted. Unmounting the view closes the EventSource.
+
+## Stream Contract
+
+The canonical Query Insights data source is a Prisma Streams JSON stream named
+`prisma-log`. Query execution records MUST be appended to that stream
+continuously by the host while queries execute, regardless of whether the Query
+Insights view is currently open.
+
+The Studio UI reads that stream through the normal Streams HTTP surface, using
+`GET /v1/stream/prisma-log?format=json&offset=-1&live=sse`. This means the UI
+receives standard Streams SSE events:
+
+- `data`: a JSON array of `prisma-log` events
+- `control`: stream cursor and up-to-date metadata, currently ignored by Query
+  Insights
+
+Each query event in the `data` batch uses `type: "query"` plus SQL, latency,
+count, reads, rows returned, tables, optional Prisma metadata, optional
+`groupKey`, optional `queryId`, and optional min/max latency. Studio derives
+one-second chart buckets from each query event timestamp and aggregates repeated
+query patterns in browser state.
+
+The client MAY still decode legacy `queries` and `chartTick` SSE event names for
+compatibility, but new demo and host integrations MUST feed Query Insights from
+`prisma-log`.
+
+## UI Contract
+
+The view uses standard ShadCN primitives for cards, buttons, badges, selects, table, and sheet.
+
+The live observability composition is Studio-specific: two Chart.js-backed metric cards feed from chart ticks, a bounded ShadCN table renders sorted and filtered query rows, and a ShadCN sheet renders details and recommendations.
+
+Selecting a row auto-pauses table updates. Closing a sheet that caused auto-pause resumes and flushes the paused buffer.
+
+## Query Visibility
+
+Studio's `Query` contract includes `meta.visibility`.
+
+Postgres adapter-generated introspection, table reads, mutations, and fallback lint helper queries MUST be marked `studio-system`. Raw SQL editor executions remain user-visible. BFF hosts should append `-- prisma:studio` to system queries before forwarding them to the database so backend Query Insights implementations can filter them consistently with `-- prisma:console`.
+
+## ppg-dev Demo
+
+The local `ppg-dev` demo hosts the Query Insights backend itself:
+
+- `/api/config` advertises the Query Insights transport URLs
+- ppg-dev ensures the `prisma-log` stream exists on the configured Prisma
+  Streams server at startup
+- `/api/query` appends the Studio system suffix to system queries, executes the database request, and appends each successful user-visible SQL execution to `prisma-log`
+- the Query Insights UI reads from `/api/streams/v1/stream/prisma-log`, so it
+  uses the same same-origin Streams proxy as the Stream view
+- `/api/query-insights/analyze` returns deterministic demo analysis
+- `/api/query-insights/enable-ai` stores consent in demo memory
+
+This keeps the demo same-origin and exercises the Studio transport without depending on production control-plane services.

--- a/Architecture/tanstack-db-performance.md
+++ b/Architecture/tanstack-db-performance.md
@@ -129,6 +129,7 @@ Any change to guard semantics MUST update tests for:
 Architecture-compliance tests MUST also cover:
 
 - allowed `createCollection(...)` boundaries in production UI code
+- stream-event row collections created through Studio context and reused by query scope
 - `cleanupOnUnmount` paths avoiding shared TanStack DB reads/writes
 - per-cell components avoiding direct global hook reads that fan out across wide grids
 - grid-wide shared context-menu usage instead of per-cell context wrappers

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -21,6 +21,13 @@ The same demo entrypoint can also run against external development infrastructur
 Studio can run without a database connection when a Streams server is configured, which makes it usable as a focused event-log and stream-search tool.
 In that mode the shell hides schema selection, table navigation, and database-only views, defaults into the stream view, and keeps all Streams browsing, search, aggregation, and live/tail behavior working through the normal `/api/streams` proxy.
 
+## Query Insights
+
+Embedders can provide a Query Insights transport that adds a native Studio view at `view=query-insights`.
+The view reads query events from a `prisma-log` Prisma Streams stream while active, buckets event timestamps into latency and queries-per-second charts, groups Prisma operations when metadata is available, and keeps the query table sortable, filterable by table, and bounded in memory.
+Selecting a row opens a Studio sheet with SQL, runtime stats, Prisma operation context, and structured recommendations after workspace-scoped AI consent.
+The `ppg-dev` demo appends user-originated SQL from `/api/query` into `prisma-log` continuously through the same Streams server used by the demo, while hiding Studio system queries.
+
 ## Local Streams Development Override
 
 Studio's local development workflow can temporarily replace the published npm `@prisma/dev` package with the sibling source package from `../team-expansion/dev/server`, while also swapping its `@prisma/streams-local` dependency over to a built local Streams checkout.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -26,7 +26,7 @@ In that mode the shell hides schema selection, table navigation, and database-on
 Embedders can provide a Query Insights transport that adds a native Studio view at `view=query-insights`.
 The view reads query events from a `prisma-log` Prisma Streams stream while active, buckets event timestamps into latency and queries-per-second charts, groups Prisma operations when metadata is available, and keeps the query table sortable, filterable by table, and bounded in memory.
 Selecting a row opens a Studio sheet with SQL, runtime stats, Prisma operation context, and structured recommendations after workspace-scoped AI consent.
-The `ppg-dev` demo appends user-originated SQL from `/api/query` into `prisma-log` continuously through the same Streams server used by the demo, while hiding Studio system queries.
+The `ppg-dev` demo appends every successful SQL execution from `/api/query` into `prisma-log` continuously through the same Streams server used by the demo, with Studio system queries annotated for downstream classification.
 
 ## Local Streams Development Override
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,7 +24,7 @@ In that mode the shell hides schema selection, table navigation, and database-on
 ## Query Insights
 
 Embedders can provide a Query Insights transport that adds a native Studio view at `view=query-insights`.
-The view reads query events from a `prisma-log` Prisma Streams stream while active, buckets event timestamps into latency and queries-per-second charts, groups Prisma operations when metadata is available, and keeps the query table sortable, filterable by table, and bounded in memory.
+The view reads query events from a `prisma-log` Prisma Streams stream while active, replays the latest stream snapshot on mount, buckets event timestamps into latency and queries-per-second charts, groups Prisma operations when metadata is available, and keeps the query table sortable, filterable by table, and bounded in memory.
 Selecting a row opens a Studio sheet with SQL, runtime stats, Prisma operation context, and structured recommendations after workspace-scoped AI consent.
 The `ppg-dev` demo appends every successful SQL execution from `/api/query` into `prisma-log` continuously through the same Streams server used by the demo, with Studio system queries annotated for downstream classification.
 

--- a/data/postgres-core/adapter.test.ts
+++ b/data/postgres-core/adapter.test.ts
@@ -66,6 +66,9 @@ describe("postgres-core/adapter", () => {
               "not ilike",
             ],
             "query": {
+              "meta": {
+                "visibility": "studio-system",
+              },
               "parameters": [
                 "",
                 "nextval(%",
@@ -485,7 +488,9 @@ describe("postgres-core/adapter", () => {
       expect(error).toBeNull();
       expect(result?.rowCount).toBe(2);
       expect(result?.rows).toEqual([{ one: 1 }, { one: 2 }]);
-      expect(result?.query.sql).toBe("select 1 as one union all select 2 as one");
+      expect(result?.query.sql).toBe(
+        "select 1 as one union all select 2 as one",
+      );
     });
 
     it("returns adapter errors for invalid SQL", async () => {

--- a/data/postgres-core/adapter.ts
+++ b/data/postgres-core/adapter.ts
@@ -1,6 +1,5 @@
 import {
   type Adapter,
-  type AdapterUpdateDetails,
   type AdapterDeleteResult,
   type AdapterError,
   type AdapterInsertResult,
@@ -12,6 +11,7 @@ import {
   type AdapterSqlLintDetails,
   type AdapterSqlLintResult,
   type AdapterSqlSchemaResult,
+  type AdapterUpdateDetails,
   type AdapterUpdateManyResult,
   type AdapterUpdateResult,
   type Column,
@@ -23,7 +23,12 @@ import {
   createFullTableSearchExecutionState,
   executeQueryWithFullTableSearchGuardrails,
 } from "../full-table-search";
-import { asQuery, type Query, QueryResult } from "../query";
+import {
+  asQuery,
+  type Query,
+  QueryResult,
+  withQueryVisibility,
+} from "../query";
 import { createSqlEditorSchemaFromIntrospection } from "../sql-editor-schema";
 import type { Either } from "../type-utils";
 import { POSTGRESQL_DATA_TYPES_TO_METADATA } from "./datatype";
@@ -46,6 +51,10 @@ import {
 
 export type PostgresAdapterRequirements = AdapterRequirements;
 
+function markStudioSystemQuery<T>(query: Query<T>): Query<T> {
+  return withQueryVisibility(query, "studio-system");
+}
+
 export function createPostgresAdapter(
   requirements: PostgresAdapterRequirements,
 ): Adapter {
@@ -61,7 +70,7 @@ export function createPostgresAdapter(
     options: Parameters<NonNullable<Adapter["update"]>>[1],
   ): Promise<Either<AdapterError, AdapterUpdateManyResult>> {
     const queries = updates.map((update) =>
-      getUpdateQuery(update, otherRequirements),
+      markStudioSystemQuery(getUpdateQuery(update, otherRequirements)),
     );
 
     try {
@@ -126,17 +135,19 @@ export function createPostgresAdapter(
     try {
       const tablesQuery = getTablesQuery(otherRequirements);
       const timezoneQuery = getTimezoneQuery();
+      const systemTablesQuery = markStudioSystemQuery(tablesQuery);
+      const systemTimezoneQuery = markStudioSystemQuery(timezoneQuery);
 
       const [[tablesError, tables], [timezoneError, timezones]] =
         await Promise.all([
-          executor.execute(tablesQuery, options),
-          executor.execute(timezoneQuery, options),
+          executor.execute(systemTablesQuery, options),
+          executor.execute(systemTimezoneQuery, options),
         ]);
 
       if (tablesError) {
         return createPostgresAdapterError({
           error: tablesError,
-          query: tablesQuery,
+          query: systemTablesQuery,
         });
       }
 
@@ -146,7 +157,7 @@ export function createPostgresAdapter(
 
       return [
         null,
-        createIntrospection({ query: tablesQuery, tables, timezone }),
+        createIntrospection({ query: systemTablesQuery, tables, timezone }),
       ];
     } catch (error: unknown) {
       return createPostgresAdapterError({ error: error as Error });
@@ -173,7 +184,9 @@ export function createPostgresAdapter(
       options,
     ): Promise<Either<AdapterError, AdapterQueryResult>> {
       try {
-        const query = getSelectQuery(details, otherRequirements);
+        const query = markStudioSystemQuery(
+          getSelectQuery(details, otherRequirements),
+        );
         const [error, results] =
           await executeQueryWithFullTableSearchGuardrails({
             executor,
@@ -268,7 +281,9 @@ export function createPostgresAdapter(
       options,
     ): Promise<Either<AdapterError, AdapterInsertResult>> {
       try {
-        const query = getInsertQuery(details, otherRequirements);
+        const query = markStudioSystemQuery(
+          getInsertQuery(details, otherRequirements),
+        );
 
         const [error, rows] = await executor.execute(query, options);
 
@@ -287,7 +302,9 @@ export function createPostgresAdapter(
       options,
     ): Promise<Either<AdapterError, AdapterUpdateResult>> {
       try {
-        const query = getUpdateQuery(details, otherRequirements);
+        const query = markStudioSystemQuery(
+          getUpdateQuery(details, otherRequirements),
+        );
 
         const [error, results] = await executor.execute(query, options);
 
@@ -319,7 +336,9 @@ export function createPostgresAdapter(
       options,
     ): Promise<Either<AdapterError, AdapterDeleteResult>> {
       try {
-        const query = getDeleteQuery(details, otherRequirements);
+        const query = markStudioSystemQuery(
+          getDeleteQuery(details, otherRequirements),
+        );
 
         const [error] = await executor.execute(query, options);
 
@@ -393,7 +412,10 @@ async function lintWithExplainFallback(
       const explainQuery = asQuery<Record<string, unknown>>(
         `EXPLAIN ${statement.statement}`,
       );
-      const [error] = await executor.execute(explainQuery, options);
+      const [error] = await executor.execute(
+        markStudioSystemQuery(explainQuery),
+        options,
+      );
 
       if (!error) {
         continue;

--- a/data/query.ts
+++ b/data/query.ts
@@ -98,6 +98,9 @@ class ImmediateValueTransformer extends OperationNodeTransformer {
 declare const queryType: unique symbol;
 export interface Query<T = Record<string, unknown>> {
   [queryType]?: T;
+  meta?: {
+    visibility?: "studio-system" | "user";
+  };
   parameters: readonly unknown[];
   sql: string;
   transformations?: Partial<Record<keyof T, "json-parse">>;
@@ -109,6 +112,19 @@ export function asQuery<T>(query: string | Query<unknown>): Query<T> {
   }
 
   return query as never;
+}
+
+export function withQueryVisibility<T>(
+  query: Query<T>,
+  visibility: NonNullable<Query["meta"]>["visibility"],
+): Query<T> {
+  return {
+    ...query,
+    meta: {
+      ...query.meta,
+      visibility,
+    },
+  };
 }
 
 export type QueryResult<T> =

--- a/demo/ppg-dev/DemoShell.tsx
+++ b/demo/ppg-dev/DemoShell.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import type { Adapter } from "../../data/adapter";
 import type { StudioLlm, StudioLlmResponse } from "../../data/llm";
 import { isStudioLlmResponse } from "../../data/llm";
-import { Studio } from "../../ui";
+import { Studio, type StudioQueryInsights } from "../../ui";
+import type { DemoConfig } from "./config";
 
 function canUseBrowserFullscreen(): boolean {
   return (
@@ -73,11 +74,19 @@ export function DemoApp(props: {
   aiEnabled: boolean;
   bootId: string;
   hasDatabase: boolean;
+  queryInsights?: DemoConfig["queryInsights"];
   seededAt?: string;
   streamsUrl?: string;
 }) {
-  const { adapter, aiEnabled, bootId, hasDatabase, seededAt, streamsUrl } =
-    props;
+  const {
+    adapter,
+    aiEnabled,
+    bootId,
+    hasDatabase,
+    queryInsights: queryInsightsConfig,
+    seededAt,
+    streamsUrl,
+  } = props;
   const llm: StudioLlm | undefined = aiEnabled
     ? async (request) => {
         const response = await fetch("/api/ai", {
@@ -111,6 +120,48 @@ export function DemoApp(props: {
             : `AI request failed (${response.status} ${response.statusText})`,
           ok: false,
         } satisfies StudioLlmResponse;
+      }
+    : undefined;
+  const queryInsights: StudioQueryInsights | undefined = queryInsightsConfig
+    ? {
+        aiRecommendationsEnabled: queryInsightsConfig.aiRecommendationsEnabled,
+        async analyze(input) {
+          const response = await fetch(queryInsightsConfig.analyzeUrl, {
+            body: JSON.stringify(input),
+            headers: {
+              "content-type": "application/json",
+            },
+            method: "POST",
+          });
+
+          if (!response.ok) {
+            return {
+              error: `Query analysis failed (${response.status} ${response.statusText})`,
+              result: null,
+            };
+          }
+
+          return (await response.json()) as Awaited<
+            ReturnType<StudioQueryInsights["analyze"]>
+          >;
+        },
+        async enableAiRecommendations() {
+          const response = await fetch(queryInsightsConfig.enableAiUrl, {
+            method: "POST",
+          });
+
+          if (!response.ok) {
+            throw new Error(
+              `Failed enabling Query Insights AI (${response.status} ${response.statusText})`,
+            );
+          }
+
+          return (await response.json()) as { ok: true };
+        },
+        onEvent(event) {
+          console.debug("[demo] query insights event", event);
+        },
+        streamUrl: queryInsightsConfig.streamUrl,
       }
     : undefined;
 
@@ -167,6 +218,7 @@ export function DemoApp(props: {
           adapter={adapter}
           hasDatabase={hasDatabase}
           llm={llm}
+          queryInsights={queryInsights}
           streamsUrl={streamsUrl}
         />
       </main>

--- a/demo/ppg-dev/build-compute.test.ts
+++ b/demo/ppg-dev/build-compute.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -139,140 +139,133 @@ afterAll(async () => {
 });
 
 describe("build-compute", () => {
-  it(
-    "copies stable Prisma dev runtime assets next to the bundled server entrypoint",
-    async () => {
-      const bunVersion = await getBunVersion();
+  it("copies stable Prisma dev runtime assets next to the bundled server entrypoint", async () => {
+    const bunVersion = await getBunVersion();
 
-      if (!bunVersion) {
-        return;
-      }
+    if (!bunVersion) {
+      return;
+    }
 
-      const outputDir = await mkdtemp(
-        join(tmpdir(), "studio-build-compute-output-"),
-      );
-      tempDirs.add(outputDir);
+    const outputDir = await mkdtemp(
+      join(tmpdir(), "studio-build-compute-output-"),
+    );
+    tempDirs.add(outputDir);
 
-      const build = await runProcess(
-        "bun",
-        ["demo/ppg-dev/build-compute.ts", outputDir],
-        {
-          cwd: process.cwd(),
-          env: {
-            STUDIO_DEMO_AI_ENABLED: "false",
-          },
-        },
-      );
-
-      expect(build.code).toBe(0);
-      expect(build.stderr).toBe("");
-
-      const rootEntries = await readdir(outputDir);
-      const bundleEntries = await readdir(join(outputDir, "bundle"));
-
-      expect(rootEntries).toContain("bundle");
-      expect(rootEntries).toContain("touch");
-      expect(rootEntries.some((entry) => entry.endsWith(".tar.gz"))).toBe(false);
-      expect(rootEntries.some((entry) => entry.endsWith(".wasm"))).toBe(false);
-      expect(rootEntries.some((entry) => entry.endsWith(".data"))).toBe(false);
-
-      expect(bundleEntries).toContain("server.bundle.js");
-      expect(bundleEntries).toContain("initdb.wasm");
-      expect(bundleEntries).toContain("pglite.data");
-      expect(bundleEntries).toContain("pglite.wasm");
-      expect(bundleEntries).toContain("pglite-seed.tar.gz");
-      expect(
-        bundleEntries.some(
-          (entry) => entry.includes(".tar-") && entry.endsWith(".gz"),
-        ),
-      ).toBe(true);
-
-      const touchEntries = await readdir(join(outputDir, "touch"));
-      const hashVendorEntries = await readdir(
-        join(outputDir, "touch", "hash_vendor"),
-      );
-      const workerBundle = await readFile(
-        join(outputDir, "touch", "processor_worker.js"),
-        "utf8",
-      );
-
-      expect(touchEntries).toContain("processor_worker.js");
-      expect(touchEntries).toContain("hash_vendor");
-      expect(hashVendorEntries).toContain("LICENSE.hash-wasm");
-      expect(hashVendorEntries).toContain("NOTICE.md");
-      expect(hashVendorEntries).toContain("xxhash3.umd.min.cjs");
-      expect(hashVendorEntries).toContain("xxhash32.umd.min.cjs");
-      expect(hashVendorEntries).toContain("xxhash64.umd.min.cjs");
-      expect(workerBundle).not.toContain('from "better-result"');
-      expect(workerBundle).not.toContain('from "ajv"');
-
-      const serverBundle = await readFile(
-        join(outputDir, "bundle", "server.bundle.js"),
-        "utf8",
-      );
-      expect(serverBundle).not.toContain(
-        "sourceMappingURL=data:application/json;base64",
-      );
-
-      if (!supportsBundledPrismaDevBoot(bunVersion)) {
-        return;
-      }
-
-      const port = await getAvailablePort();
-      const serverProcess = spawn("bun", ["./bundle/server.bundle.js"], {
-        cwd: outputDir,
+    const build = await runProcess(
+      "bun",
+      ["demo/ppg-dev/build-compute.ts", outputDir],
+      {
+        cwd: process.cwd(),
         env: {
-          ...process.env,
           STUDIO_DEMO_AI_ENABLED: "false",
-          STUDIO_DEMO_PORT: String(port),
         },
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      },
+    );
 
-      let stdout = "";
-      let stderr = "";
+    expect(build.code).toBe(0);
+    expect(build.stderr).toBe("");
 
-      serverProcess.stdout.on("data", (chunk) => {
-        stdout += String(chunk);
-      });
-      serverProcess.stderr.on("data", (chunk) => {
-        stderr += String(chunk);
-      });
+    const rootEntries = await readdir(outputDir);
+    const bundleEntries = await readdir(join(outputDir, "bundle"));
 
-      try {
-        const response = await waitForHttp(
-          `http://127.0.0.1:${port}/api/config`,
-        );
-        const payload = (await response.json()) as {
-          bootId?: unknown;
-          streams?: {
-            url?: unknown;
-          };
+    expect(rootEntries).toContain("bundle");
+    expect(rootEntries).toContain("touch");
+    expect(rootEntries.some((entry) => entry.endsWith(".tar.gz"))).toBe(false);
+    expect(rootEntries.some((entry) => entry.endsWith(".wasm"))).toBe(false);
+    expect(rootEntries.some((entry) => entry.endsWith(".data"))).toBe(false);
+
+    expect(bundleEntries).toContain("server.bundle.js");
+    expect(bundleEntries).toContain("initdb.wasm");
+    expect(bundleEntries).toContain("pglite.data");
+    expect(bundleEntries).toContain("pglite.wasm");
+    expect(
+      bundleEntries.some(
+        (entry) => entry.includes(".tar-") && entry.endsWith(".gz"),
+      ),
+    ).toBe(true);
+
+    const touchEntries = await readdir(join(outputDir, "touch"));
+    const hashVendorEntries = await readdir(
+      join(outputDir, "touch", "hash_vendor"),
+    );
+    const workerBundle = await readFile(
+      join(outputDir, "touch", "processor_worker.js"),
+      "utf8",
+    );
+
+    expect(touchEntries).toContain("processor_worker.js");
+    expect(touchEntries).toContain("hash_vendor");
+    expect(hashVendorEntries).toContain("LICENSE.hash-wasm");
+    expect(hashVendorEntries).toContain("NOTICE.md");
+    expect(hashVendorEntries).toContain("xxhash3.umd.min.cjs");
+    expect(hashVendorEntries).toContain("xxhash32.umd.min.cjs");
+    expect(hashVendorEntries).toContain("xxhash64.umd.min.cjs");
+    expect(workerBundle).not.toContain('from "better-result"');
+    expect(workerBundle).not.toContain('from "ajv"');
+
+    const serverBundle = await readFile(
+      join(outputDir, "bundle", "server.bundle.js"),
+      "utf8",
+    );
+    expect(serverBundle).not.toContain(
+      "sourceMappingURL=data:application/json;base64",
+    );
+
+    if (!supportsBundledPrismaDevBoot(bunVersion)) {
+      return;
+    }
+
+    const port = await getAvailablePort();
+    const serverProcess = spawn("bun", ["./bundle/server.bundle.js"], {
+      cwd: outputDir,
+      env: {
+        ...process.env,
+        STUDIO_DEMO_AI_ENABLED: "false",
+        STUDIO_DEMO_PORT: String(port),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    serverProcess.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    serverProcess.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+
+    try {
+      const response = await waitForHttp(`http://127.0.0.1:${port}/api/config`);
+      const payload = (await response.json()) as {
+        bootId?: unknown;
+        streams?: {
+          url?: unknown;
         };
+      };
 
-        expect(typeof payload.bootId).toBe("string");
-        expect(typeof payload.streams?.url).toBe("string");
-        expect(payload.streams?.url).toBe("/api/streams");
+      expect(typeof payload.bootId).toBe("string");
+      expect(typeof payload.streams?.url).toBe("string");
+      expect(payload.streams?.url).toBe("/api/streams");
 
-        const faviconResponse = await fetch(
-          `http://127.0.0.1:${port}/favicon.ico`,
-        );
-        expect(faviconResponse.status).toBe(204);
-      } finally {
-        serverProcess.kill("SIGTERM");
-        if (
-          serverProcess.exitCode === null &&
-          serverProcess.signalCode === null
-        ) {
-          await new Promise<void>((resolve) => {
-            serverProcess.once("close", () => resolve());
-          });
-        }
+      const faviconResponse = await fetch(
+        `http://127.0.0.1:${port}/favicon.ico`,
+      );
+      expect(faviconResponse.status).toBe(204);
+    } finally {
+      serverProcess.kill("SIGTERM");
+      if (
+        serverProcess.exitCode === null &&
+        serverProcess.signalCode === null
+      ) {
+        await new Promise<void>((resolve) => {
+          serverProcess.once("close", () => resolve());
+        });
       }
+    }
 
-      expect(normalizeBundledServerStderr(stderr)).toBe("");
-      expect(stdout).toContain(`http://localhost:${port}`);
-    },
-    120_000,
-  );
+    expect(normalizeBundledServerStderr(stderr)).toBe("");
+    expect(stdout).toContain(`http://localhost:${port}`);
+  }, 120_000);
 });

--- a/demo/ppg-dev/client.tsx
+++ b/demo/ppg-dev/client.tsx
@@ -51,6 +51,7 @@ async function bootstrap(): Promise<void> {
       hasDatabase={config.database.enabled}
       seededAt={config.seededAt}
       aiEnabled={config.ai?.enabled === true}
+      queryInsights={config.queryInsights}
       streamsUrl={config.streams?.url}
     />,
   );

--- a/demo/ppg-dev/config.ts
+++ b/demo/ppg-dev/config.ts
@@ -6,6 +6,12 @@ export interface DemoConfig {
   database: {
     enabled: boolean;
   };
+  queryInsights?: {
+    aiRecommendationsEnabled: boolean;
+    analyzeUrl: string;
+    enableAiUrl: string;
+    streamUrl: string;
+  };
   seededAt?: string;
   streams?: {
     url: string;
@@ -50,10 +56,18 @@ export function buildDemoConfig(args: {
   aiEnabled: boolean;
   bootId: string;
   databaseEnabled: boolean;
+  queryInsights?: DemoConfig["queryInsights"];
   seededAt?: string | null;
   streamsUrl?: string;
 }): DemoConfig {
-  const { aiEnabled, bootId, databaseEnabled, seededAt, streamsUrl } = args;
+  const {
+    aiEnabled,
+    bootId,
+    databaseEnabled,
+    queryInsights,
+    seededAt,
+    streamsUrl,
+  } = args;
 
   return {
     ai: {
@@ -63,6 +77,11 @@ export function buildDemoConfig(args: {
     database: {
       enabled: databaseEnabled,
     },
+    ...(queryInsights
+      ? {
+          queryInsights,
+        }
+      : {}),
     ...(seededAt
       ? {
           seededAt,

--- a/demo/ppg-dev/query-insights.test.ts
+++ b/demo/ppg-dev/query-insights.test.ts
@@ -4,6 +4,7 @@ import {
   analyzeDemoQueryInsight,
   appendStudioSystemQuerySuffix,
   createQueryInsightsLogEvent,
+  getQueryInsightsQueryVisibility,
   isStudioSystemQuery,
   parseSqlTableNames,
   QUERY_INSIGHTS_LOG_STREAM_NAME,
@@ -22,6 +23,7 @@ describe("ppg-dev Query Insights helpers", () => {
       `select * from pg_catalog.pg_class ${STUDIO_SYSTEM_QUERY_SUFFIX}`,
     );
     expect(isStudioSystemQuery(tagged)).toBe(true);
+    expect(getQueryInsightsQueryVisibility(tagged)).toBe("studio-system");
     expect(
       isStudioSystemQuery({
         meta: { visibility: "user" },
@@ -43,7 +45,7 @@ describe("ppg-dev Query Insights helpers", () => {
     expect(parseSqlTableNames("select * from pg_catalog.pg_class")).toEqual([]);
   });
 
-  it("builds prisma-log query events and skips Studio system queries", () => {
+  it("builds prisma-log query events for user and Studio system queries", () => {
     const event = createQueryInsightsLogEvent({
       durationMs: 12.5,
       query: {
@@ -63,14 +65,30 @@ describe("ppg-dev Query Insights helpers", () => {
       tables: ["organizations"],
       ts: 1_700_000_000_000,
       type: "query",
+      visibility: "user",
+    });
+    const systemEvent = createQueryInsightsLogEvent({
+      durationMs: 1,
+      query: appendStudioSystemQuerySuffix({
+        meta: { visibility: "studio-system" },
+        parameters: [],
+        sql: "select * from pg_catalog.pg_class",
+      }),
+      rows: [],
+      ts: 1_700_000_000_001,
+    });
+
+    expect(systemEvent).toMatchObject({
+      sql: "select * from pg_catalog.pg_class",
+      type: "query",
+      visibility: "studio-system",
     });
     expect(
       createQueryInsightsLogEvent({
         durationMs: 1,
         query: {
-          meta: { visibility: "studio-system" },
           parameters: [],
-          sql: "select * from pg_catalog.pg_class",
+          sql: "   ",
         },
         rows: [],
       }),

--- a/demo/ppg-dev/query-insights.test.ts
+++ b/demo/ppg-dev/query-insights.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeDemoQueryInsight,
+  appendStudioSystemQuerySuffix,
+  createQueryInsightsLogEvent,
+  isStudioSystemQuery,
+  parseSqlTableNames,
+  QUERY_INSIGHTS_LOG_STREAM_NAME,
+  STUDIO_SYSTEM_QUERY_SUFFIX,
+} from "./query-insights";
+
+describe("ppg-dev Query Insights helpers", () => {
+  it("tags and detects Studio system queries", () => {
+    const tagged = appendStudioSystemQuerySuffix({
+      meta: { visibility: "studio-system" },
+      parameters: [],
+      sql: "select * from pg_catalog.pg_class",
+    });
+
+    expect(tagged.sql).toBe(
+      `select * from pg_catalog.pg_class ${STUDIO_SYSTEM_QUERY_SUFFIX}`,
+    );
+    expect(isStudioSystemQuery(tagged)).toBe(true);
+    expect(
+      isStudioSystemQuery({
+        meta: { visibility: "user" },
+        parameters: [],
+        sql: "select * from users",
+      }),
+    ).toBe(false);
+  });
+
+  it("extracts complete table names from common SQL statements", () => {
+    expect(
+      parseSqlTableNames(
+        'select * from organizations join "team_members" on true',
+      ),
+    ).toEqual(["organizations", "team_members"]);
+    expect(
+      parseSqlTableNames("update public.incidents set severity = 2"),
+    ).toEqual(["public.incidents"]);
+    expect(parseSqlTableNames("select * from pg_catalog.pg_class")).toEqual([]);
+  });
+
+  it("builds prisma-log query events and skips Studio system queries", () => {
+    const event = createQueryInsightsLogEvent({
+      durationMs: 12.5,
+      query: {
+        parameters: [],
+        sql: "select * from organizations limit 3",
+      },
+      rows: [{ id: 1 }, { id: 2 }],
+      ts: 1_700_000_000_000,
+    });
+
+    expect(QUERY_INSIGHTS_LOG_STREAM_NAME).toBe("prisma-log");
+    expect(event).toMatchObject({
+      count: 1,
+      durationMs: 12.5,
+      rowsReturned: 2,
+      sql: "select * from organizations limit 3",
+      tables: ["organizations"],
+      ts: 1_700_000_000_000,
+      type: "query",
+    });
+    expect(
+      createQueryInsightsLogEvent({
+        durationMs: 1,
+        query: {
+          meta: { visibility: "studio-system" },
+          parameters: [],
+          sql: "select * from pg_catalog.pg_class",
+        },
+        rows: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns deterministic demo analysis for broad select queries", () => {
+    const result = analyzeDemoQueryInsight({
+      queryStats: {
+        count: 1,
+        duration: 125,
+        reads: 0,
+        rowsReturned: 150,
+      },
+      rawQuery: "select * from users",
+    });
+
+    expect(result.isOptimal).toBe(false);
+    expect(result.recommendations.join(" ")).toContain("LIMIT");
+    expect(result.improvedSql).toContain("LIMIT 50");
+  });
+});

--- a/demo/ppg-dev/query-insights.ts
+++ b/demo/ppg-dev/query-insights.ts
@@ -2,6 +2,7 @@ import type { Query } from "../../data/query";
 import type {
   QueryInsightsAnalysisResult,
   QueryInsightsAnalyzeInput,
+  QueryInsightsQueryVisibility,
   QueryInsightsStreamQuery,
 } from "../../ui/studio/views/query-insights/types";
 
@@ -11,6 +12,7 @@ const CONSOLE_SYSTEM_QUERY_SUFFIX = "-- prisma:console";
 
 export interface QueryInsightsLogEvent extends QueryInsightsStreamQuery {
   type: "query";
+  visibility: QueryInsightsQueryVisibility;
 }
 
 function normalizeSql(sql: string): string {
@@ -30,6 +32,12 @@ export function isStudioSystemQuery(query: Query<unknown>): boolean {
     query.sql.includes(STUDIO_SYSTEM_QUERY_SUFFIX) ||
     query.sql.includes(CONSOLE_SYSTEM_QUERY_SUFFIX)
   );
+}
+
+export function getQueryInsightsQueryVisibility(
+  query: Query<unknown>,
+): QueryInsightsQueryVisibility {
+  return isStudioSystemQuery(query) ? "studio-system" : "user";
 }
 
 export function appendStudioSystemQuerySuffix<T>(query: Query<T>): Query<T> {
@@ -76,10 +84,6 @@ export function createQueryInsightsLogEvent(args: {
   rows: unknown;
   ts?: number;
 }): QueryInsightsLogEvent | null {
-  if (isStudioSystemQuery(args.query)) {
-    return null;
-  }
-
   const cleanedSql = stripKnownSystemSuffixes(args.query.sql);
   const normalizedSql = normalizeSql(cleanedSql);
 
@@ -103,6 +107,7 @@ export function createQueryInsightsLogEvent(args: {
     tables: parseSqlTableNames(cleanedSql),
     ts: args.ts ?? Date.now(),
     type: "query",
+    visibility: getQueryInsightsQueryVisibility(args.query),
   };
 }
 

--- a/demo/ppg-dev/query-insights.ts
+++ b/demo/ppg-dev/query-insights.ts
@@ -1,0 +1,237 @@
+import type { Query } from "../../data/query";
+import type {
+  QueryInsightsAnalysisResult,
+  QueryInsightsAnalyzeInput,
+  QueryInsightsStreamQuery,
+} from "../../ui/studio/views/query-insights/types";
+
+export const STUDIO_SYSTEM_QUERY_SUFFIX = "-- prisma:studio";
+export const QUERY_INSIGHTS_LOG_STREAM_NAME = "prisma-log";
+const CONSOLE_SYSTEM_QUERY_SUFFIX = "-- prisma:console";
+
+export interface QueryInsightsLogEvent extends QueryInsightsStreamQuery {
+  type: "query";
+}
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim();
+}
+
+function stripKnownSystemSuffixes(sql: string): string {
+  return sql
+    .replaceAll(STUDIO_SYSTEM_QUERY_SUFFIX, "")
+    .replaceAll(CONSOLE_SYSTEM_QUERY_SUFFIX, "")
+    .trim();
+}
+
+export function isStudioSystemQuery(query: Query<unknown>): boolean {
+  return (
+    query.meta?.visibility === "studio-system" ||
+    query.sql.includes(STUDIO_SYSTEM_QUERY_SUFFIX) ||
+    query.sql.includes(CONSOLE_SYSTEM_QUERY_SUFFIX)
+  );
+}
+
+export function appendStudioSystemQuerySuffix<T>(query: Query<T>): Query<T> {
+  if (query.meta?.visibility !== "studio-system") {
+    return query;
+  }
+
+  if (query.sql.includes(STUDIO_SYSTEM_QUERY_SUFFIX)) {
+    return query;
+  }
+
+  return {
+    ...query,
+    sql: `${query.sql.trim()} ${STUDIO_SYSTEM_QUERY_SUFFIX}`,
+  };
+}
+
+export function parseSqlTableNames(sql: string): string[] {
+  const tables = new Set<string>();
+  const patterns = [
+    /\bfrom\s+("?[\w.]+"?)/gi,
+    /\bjoin\s+("?[\w.]+"?)/gi,
+    /\bupdate\s+("?[\w.]+"?)/gi,
+    /\binsert\s+into\s+("?[\w.]+"?)/gi,
+    /\bdelete\s+from\s+("?[\w.]+"?)/gi,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of sql.matchAll(pattern)) {
+      const table = match[1]?.replaceAll('"', "").trim();
+
+      if (table && !table.startsWith("pg_catalog.")) {
+        tables.add(table);
+      }
+    }
+  }
+
+  return Array.from(tables).sort();
+}
+
+export function createQueryInsightsLogEvent(args: {
+  durationMs: number;
+  query: Query<unknown>;
+  rows: unknown;
+  ts?: number;
+}): QueryInsightsLogEvent | null {
+  if (isStudioSystemQuery(args.query)) {
+    return null;
+  }
+
+  const cleanedSql = stripKnownSystemSuffixes(args.query.sql);
+  const normalizedSql = normalizeSql(cleanedSql);
+
+  if (normalizedSql.length === 0) {
+    return null;
+  }
+
+  const durationMs = Math.max(0, args.durationMs);
+
+  return {
+    count: 1,
+    durationMs,
+    groupKey: null,
+    maxDurationMs: durationMs,
+    minDurationMs: durationMs,
+    prismaQueryInfo: null,
+    queryId: null,
+    reads: 0,
+    rowsReturned: Array.isArray(args.rows) ? args.rows.length : 0,
+    sql: cleanedSql,
+    tables: parseSqlTableNames(cleanedSql),
+    ts: args.ts ?? Date.now(),
+    type: "query",
+  };
+}
+
+function createStreamsApiUrl(
+  streamsServerUrl: string,
+  streamName: string,
+): string {
+  const url = new URL(
+    `v1/stream/${encodeURIComponent(streamName)}`,
+    `${streamsServerUrl.replace(/\/+$/, "")}/`,
+  );
+
+  return url.toString();
+}
+
+async function getResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return response.statusText;
+  }
+}
+
+export async function ensureQueryInsightsLogStream(args: {
+  fetchFn?: typeof fetch;
+  streamsServerUrl: string;
+}): Promise<void> {
+  const fetchFn = args.fetchFn ?? fetch;
+  const response = await fetchFn(
+    createStreamsApiUrl(args.streamsServerUrl, QUERY_INSIGHTS_LOG_STREAM_NAME),
+    {
+      body: "[]",
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "PUT",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed ensuring ${QUERY_INSIGHTS_LOG_STREAM_NAME} stream (${response.status} ${await getResponseText(response)})`,
+    );
+  }
+}
+
+export async function appendQueryInsightsLogEvent(args: {
+  event: QueryInsightsLogEvent;
+  fetchFn?: typeof fetch;
+  streamsServerUrl: string;
+}): Promise<void> {
+  const fetchFn = args.fetchFn ?? fetch;
+  const url = createStreamsApiUrl(
+    args.streamsServerUrl,
+    QUERY_INSIGHTS_LOG_STREAM_NAME,
+  );
+  const append = () =>
+    fetchFn(url, {
+      body: JSON.stringify(args.event),
+      headers: {
+        "content-type": "application/json",
+        "stream-timestamp": new Date(args.event.ts).toISOString(),
+      },
+      method: "POST",
+    });
+  let response = await append();
+
+  if (response.status === 404) {
+    await ensureQueryInsightsLogStream({
+      fetchFn,
+      streamsServerUrl: args.streamsServerUrl,
+    });
+    response = await append();
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed appending ${QUERY_INSIGHTS_LOG_STREAM_NAME} event (${response.status} ${await getResponseText(response)})`,
+    );
+  }
+}
+
+export function analyzeDemoQueryInsight(
+  input: QueryInsightsAnalyzeInput,
+): QueryInsightsAnalysisResult {
+  const stats = input.queryStats;
+  const isSlow = (stats?.duration ?? 0) >= 100;
+  const returnsManyRows = (stats?.rowsReturned ?? 0) >= 100;
+  const selectWithoutLimit =
+    /^\s*select\b/i.test(input.rawQuery) && !/\blimit\b/i.test(input.rawQuery);
+  const recommendations: string[] = [];
+  const issuesFound: string[] = [];
+
+  if (isSlow) {
+    issuesFound.push(
+      "Average latency is high for an interactive Studio query.",
+    );
+    recommendations.push(
+      "Inspect predicates and add an index for the most selective filter columns.",
+    );
+  }
+
+  if (returnsManyRows || selectWithoutLimit) {
+    issuesFound.push("The query can return more rows than an operator needs.");
+    recommendations.push(
+      "Add a LIMIT clause or narrow the selected columns to reduce transferred rows.",
+    );
+  }
+
+  if (issuesFound.length === 0) {
+    return {
+      analysisMarkdown:
+        "# Query looks healthy\n\nNo obvious issue was detected from the available demo runtime statistics.",
+      confidenceScore: 0.72,
+      isOptimal: true,
+      issuesFound: [],
+      recommendations: [],
+    };
+  }
+
+  return {
+    analysisMarkdown:
+      "# Query can be tightened\n\n## What to do\nUse the recommendations below to reduce latency or returned rows.\n\n## Why this matters\nThe ppg-dev demo captures query timing from the Studio BFF path and flags high-latency or broad result-set patterns.",
+    confidenceScore: 0.68,
+    improvedSql: selectWithoutLimit
+      ? `${input.rawQuery.replace(/;+\s*$/, "")}\nLIMIT 50;`
+      : undefined,
+    isOptimal: false,
+    issuesFound,
+    recommendations,
+  };
+}

--- a/demo/ppg-dev/server.ts
+++ b/demo/ppg-dev/server.ts
@@ -12,9 +12,18 @@ import {
   type StudioLlmRequest,
   type StudioLlmResponse,
 } from "../../data/llm";
+import type { Query } from "../../data/query";
 import pkg from "../../package.json" with { type: "json" };
 import { AnthropicOutputLimitError, runAnthropicLlmRequest } from "./anthropic";
 import { buildDemoConfig, resolveDemoAiEnabled } from "./config";
+import {
+  analyzeDemoQueryInsight,
+  appendQueryInsightsLogEvent,
+  appendStudioSystemQuerySuffix,
+  createQueryInsightsLogEvent,
+  ensureQueryInsightsLogStream,
+  QUERY_INSIGHTS_LOG_STREAM_NAME,
+} from "./query-insights";
 import { type DemoRuntime, startDemoRuntime } from "./runtime";
 import {
   formatDemoRuntimeUsage,
@@ -63,7 +72,7 @@ type BuiltAsset = {
   contentType: string;
 };
 
-type PostgresExecutor = DemoRuntime["postgresExecutor"];
+type PostgresExecutor = NonNullable<DemoRuntime["postgresExecutor"]>;
 
 // When the server is bundled by build-compute.ts, the virtual:prebuilt-assets
 // module is resolved at bundle time and provides the pre-built client JS, CSS,
@@ -96,6 +105,8 @@ const AI_ENABLED = resolveDemoAiEnabled({
 });
 const BOOT_ID = crypto.randomUUID();
 const STREAMS_PROXY_BASE_PATH = "/api/streams";
+const QUERY_INSIGHTS_ANALYZE_PATH = "/api/query-insights/analyze";
+const QUERY_INSIGHTS_ENABLE_AI_PATH = "/api/query-insights/enable-ai";
 const CACHE_CONTROL_STATIC = isProduction
   ? "public, max-age=31536000, immutable"
   : "no-cache, no-store, must-revalidate";
@@ -147,6 +158,7 @@ let appStyles = "";
 let builtAssets = new Map<string, BuiltAsset>();
 let assetVersion = 0;
 let assetError: string | null = null;
+let queryInsightsAiRecommendationsEnabled = false;
 
 let isBuilding = false;
 let isBuildQueued = false;
@@ -272,6 +284,10 @@ async function main(): Promise<void> {
   seededAt = runtime.seededAt;
   streamsServerUrl = runtime.streamsServerUrl;
 
+  if (streamsServerUrl && postgresExecutor) {
+    await ensureQueryInsightsLogStream({ streamsServerUrl });
+  }
+
   if (prebuiltAssets) {
     appScript = prebuiltAssets.appScript;
     appStyles = prebuiltAssets.appStyles;
@@ -344,6 +360,15 @@ async function handleRequest(request: Request): Promise<Response> {
         aiEnabled: AI_ENABLED,
         bootId: BOOT_ID,
         databaseEnabled: postgresExecutor != null,
+        queryInsights:
+          postgresExecutor != null && streamsServerUrl
+            ? {
+                aiRecommendationsEnabled: queryInsightsAiRecommendationsEnabled,
+                analyzeUrl: QUERY_INSIGHTS_ANALYZE_PATH,
+                enableAiUrl: QUERY_INSIGHTS_ENABLE_AI_PATH,
+                streamUrl: createQueryInsightsBrowserStreamUrl(),
+              }
+            : undefined,
         seededAt,
         streamsUrl: streamsServerUrl ? STREAMS_PROXY_BASE_PATH : undefined,
       }),
@@ -356,6 +381,14 @@ async function handleRequest(request: Request): Promise<Response> {
 
   if (url.pathname === "/api/ai") {
     return await handleAiRequest(request);
+  }
+
+  if (url.pathname === QUERY_INSIGHTS_ANALYZE_PATH) {
+    return await handleQueryInsightsAnalyzeRequest(request);
+  }
+
+  if (url.pathname === QUERY_INSIGHTS_ENABLE_AI_PATH) {
+    return handleQueryInsightsEnableAiRequest(request);
   }
 
   if (
@@ -426,6 +459,19 @@ async function handleRequest(request: Request): Promise<Response> {
   return new Response("Not Found", { status: 404 });
 }
 
+function createQueryInsightsBrowserStreamUrl(): string {
+  const searchParams = new URLSearchParams({
+    format: "json",
+    live: "sse",
+    offset: "-1",
+    timeout: "30s",
+  });
+
+  return `${STREAMS_PROXY_BASE_PATH}/v1/stream/${encodeURIComponent(
+    QUERY_INSIGHTS_LOG_STREAM_NAME,
+  )}?${searchParams.toString()}`;
+}
+
 async function handleBffQueryRequest(request: Request): Promise<Response> {
   if (request.method === "OPTIONS") {
     return new Response(null, {
@@ -461,7 +507,7 @@ async function handleBffQueryRequest(request: Request): Promise<Response> {
   try {
     if (payload.procedure === "query") {
       const [error, result] = await runSerializedQuery(() =>
-        executor.execute(payload.query),
+        executeBffQuery(executor, payload.query),
       );
 
       return Response.json([error ? serializeError(error) : null, result]);
@@ -475,7 +521,7 @@ async function handleBffQueryRequest(request: Request): Promise<Response> {
       }
 
       const [firstError, firstResult] = await runSerializedQuery(() =>
-        executor.execute(firstQuery),
+        executeBffQuery(executor, firstQuery),
       );
 
       if (firstError) {
@@ -483,7 +529,7 @@ async function handleBffQueryRequest(request: Request): Promise<Response> {
       }
 
       const [secondError, secondResult] = await runSerializedQuery(() =>
-        executor.execute(secondQuery),
+        executeBffQuery(executor, secondQuery),
       );
 
       if (secondError) {
@@ -514,7 +560,7 @@ async function handleBffQueryRequest(request: Request): Promise<Response> {
       > = (queries, options) => executor.executeTransaction!(queries, options);
 
       const [error, result] = await runSerializedQuery(() =>
-        executeTransaction(payload.queries),
+        executeBffTransaction(executeTransaction, payload.queries),
       );
 
       return Response.json([error ? serializeError(error) : null, result]);
@@ -542,6 +588,162 @@ async function handleBffQueryRequest(request: Request): Promise<Response> {
   } catch (error: unknown) {
     return Response.json([serializeError(error)]);
   }
+}
+
+async function executeBffQuery<T>(
+  executor: PostgresExecutor,
+  query: Query<T>,
+): ReturnType<PostgresExecutor["execute"]> {
+  const preparedQuery = appendStudioSystemQuerySuffix(query);
+  const startedAt = performance.now();
+  const result = await executor.execute(preparedQuery);
+  const durationMs = Math.max(0, performance.now() - startedAt);
+  const [error, rows] = result;
+
+  if (!error) {
+    await appendQueryInsightsLog({
+      durationMs,
+      query: preparedQuery,
+      rows,
+    });
+  }
+
+  return result;
+}
+
+async function executeBffTransaction(
+  executeTransaction: NonNullable<PostgresExecutor["executeTransaction"]>,
+  queries: readonly Query<unknown>[],
+): ReturnType<NonNullable<PostgresExecutor["executeTransaction"]>> {
+  const preparedQueries = queries.map(appendStudioSystemQuerySuffix);
+  const startedAt = performance.now();
+  const result = await executeTransaction(preparedQueries);
+  const durationMs = Math.max(0, performance.now() - startedAt);
+  const [error, results] = result;
+
+  if (!error) {
+    const perQueryDurationMs =
+      preparedQueries.length > 0 ? durationMs / preparedQueries.length : 0;
+
+    for (const [index, query] of preparedQueries.entries()) {
+      await appendQueryInsightsLog({
+        durationMs: perQueryDurationMs,
+        query,
+        rows: results[index],
+      });
+    }
+  }
+
+  return result;
+}
+
+async function appendQueryInsightsLog(args: {
+  durationMs: number;
+  query: Query<unknown>;
+  rows: unknown;
+}): Promise<void> {
+  const activeStreamsServerUrl = streamsServerUrl;
+
+  if (!activeStreamsServerUrl) {
+    return;
+  }
+
+  const event = createQueryInsightsLogEvent(args);
+
+  if (!event) {
+    return;
+  }
+
+  try {
+    await appendQueryInsightsLogEvent({
+      event,
+      streamsServerUrl: activeStreamsServerUrl,
+    });
+  } catch (error) {
+    console.warn(
+      `[demo] failed to append ${QUERY_INSIGHTS_LOG_STREAM_NAME} event: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function handleQueryInsightsAnalyzeRequest(
+  request: Request,
+): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        Allow: "POST,OPTIONS",
+      },
+      status: 204,
+    });
+  }
+
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", {
+      headers: {
+        Allow: "POST,OPTIONS",
+      },
+      status: 405,
+    });
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return Response.json(
+      {
+        error: "Invalid JSON payload",
+        result: null,
+      },
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    typeof (payload as { rawQuery?: unknown }).rawQuery !== "string"
+  ) {
+    return Response.json(
+      {
+        error: "Invalid request body",
+        result: null,
+      },
+      { status: 400 },
+    );
+  }
+
+  return Response.json({
+    error: null,
+    result: analyzeDemoQueryInsight(
+      payload as Parameters<typeof analyzeDemoQueryInsight>[0],
+    ),
+  });
+}
+
+function handleQueryInsightsEnableAiRequest(request: Request): Response {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        Allow: "POST,OPTIONS",
+      },
+      status: 204,
+    });
+  }
+
+  if (request.method !== "POST") {
+    return new Response("Method Not Allowed", {
+      headers: {
+        Allow: "POST,OPTIONS",
+      },
+      status: 405,
+    });
+  }
+
+  queryInsightsAiRecommendationsEnabled = true;
+  return Response.json({ ok: true });
 }
 
 async function handleAiRequest(request: Request): Promise<Response> {

--- a/ui/components/ui/select.test.tsx
+++ b/ui/components/ui/select.test.tsx
@@ -1,0 +1,55 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("SelectContent", () => {
+  it("uses the Studio sans font inside the portal", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Select open value="all">
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="all">All tables</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>,
+      );
+
+      await Promise.resolve();
+    });
+
+    expect(document.body.innerHTML).toContain("All tables");
+    expect(
+      document.body.querySelector<HTMLElement>('[role="listbox"]')?.className,
+    ).toContain("font-sans");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+});

--- a/ui/components/ui/select.tsx
+++ b/ui/components/ui/select.tsx
@@ -80,7 +80,7 @@ const SelectContent = React.forwardRef<
       <SelectPrimitive.Content
         ref={ref}
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-select-content-transform-origin)",
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border border-border bg-popover font-sans text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-select-content-transform-origin)",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -50,27 +50,46 @@ const sheetVariants = cva(
 interface SheetContentProps
   extends
     React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  container?: HTMLElement | null;
+  showCloseButton?: boolean;
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="size-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-      {children}
-    </SheetPrimitive.Content>
-  </SheetPortal>
-));
+>(
+  (
+    {
+      side = "right",
+      className,
+      children,
+      container,
+      showCloseButton = true,
+      ...props
+    },
+    ref,
+  ) => (
+    <SheetPortal container={container ?? undefined}>
+      <div className="ps">
+        <SheetOverlay />
+        <SheetPrimitive.Content
+          ref={ref}
+          className={cn(sheetVariants({ side }), className)}
+          {...props}
+        >
+          {showCloseButton ? (
+            <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+              <X className="size-4" />
+              <span className="sr-only">Close</span>
+            </SheetPrimitive.Close>
+          ) : null}
+          {children}
+        </SheetPrimitive.Content>
+      </div>
+    </SheetPortal>
+  ),
+);
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 const SheetHeader = ({

--- a/ui/hooks/nuqs.ts
+++ b/ui/hooks/nuqs.ts
@@ -21,6 +21,8 @@ export type StateKey =
   | "pageIndex"
   | "pageSize"
   | "pin"
+  | "queryInsightsSort"
+  | "queryInsightsTable"
   | "streamAggregationRange"
   | "streamFollow"
   | "streamRoutingKey"

--- a/ui/hooks/use-introspection.test.tsx
+++ b/ui/hooks/use-introspection.test.tsx
@@ -13,12 +13,15 @@ import type {
 import type { StudioEventBase } from "../studio/Studio";
 import { useIntrospection } from "./use-introspection";
 
-const useStudioMock = vi.fn<
-  () => {
-    adapter: Adapter;
-    onEvent: (event: StudioEventBase) => void;
-  }
->();
+const { useStudioMock } = vi.hoisted(() => ({
+  useStudioMock: vi.fn<
+    () => {
+      adapter: Adapter;
+      hasDatabase: boolean;
+      onEvent: (event: StudioEventBase) => void;
+    }
+  >(),
+}));
 
 vi.mock("../studio/context", () => ({
   useStudio: useStudioMock,
@@ -116,6 +119,7 @@ function renderHarness(args: {
 
   useStudioMock.mockReturnValue({
     adapter,
+    hasDatabase: true,
     onEvent,
   });
 

--- a/ui/hooks/use-navigation.tsx
+++ b/ui/hooks/use-navigation.tsx
@@ -110,8 +110,13 @@ function buildNavigationTableNames(introspection: AdapterIntrospectResult) {
  * implement a specialized hook instead.
  */
 function useNavigationInternal() {
-  const { adapter, hasDatabase, navigationTableNamesCollection, streamsUrl } =
-    useStudio();
+  const {
+    adapter,
+    hasDatabase,
+    navigationTableNamesCollection,
+    queryInsights,
+    streamsUrl,
+  } = useStudio();
   const { data: introspection, isFetching } = useIntrospection();
 
   const { schemas } = introspection;
@@ -172,6 +177,10 @@ function useNavigationInternal() {
     defaultValue: defaults.pageSize,
   });
   const [pinParam, setPinParam] = useQueryState("pin");
+  const [queryInsightsSortParam, setQueryInsightsSortParam] =
+    useQueryState("queryInsightsSort");
+  const [queryInsightsTableParam, setQueryInsightsTableParam] =
+    useQueryState("queryInsightsTable");
   const [schemaParam, setSchemaParam] = useQueryState("schema", {
     defaultValue: defaults.schema,
   });
@@ -216,7 +225,11 @@ function useNavigationInternal() {
       ? activeTables[resolvedTableParam]
       : undefined;
   const resolvedViewParam =
-    !hasDatabase && typeof streamsUrl === "string" ? "stream" : viewParam;
+    !hasDatabase && typeof streamsUrl === "string"
+      ? "stream"
+      : viewParam === "query-insights" && (!hasDatabase || !queryInsights)
+        ? defaults.view
+        : viewParam;
 
   const metadata = useMemo(
     () => ({
@@ -235,6 +248,8 @@ function useNavigationInternal() {
     pageIndexParam,
     pageSizeParam,
     pinParam,
+    queryInsightsSortParam,
+    queryInsightsTableParam,
     schemaParam,
     searchParam,
     searchScopeParam,
@@ -250,6 +265,10 @@ function useNavigationInternal() {
     setPageIndexParam: setPageIndexParam as NuqsSetNullableValue<string>,
     setPageSizeParam: setPageSizeParam as NuqsSetNullableValue<string>,
     setPinParam: setPinParam as NuqsSetNullableValue<string>,
+    setQueryInsightsSortParam:
+      setQueryInsightsSortParam as NuqsSetNullableValue<string>,
+    setQueryInsightsTableParam:
+      setQueryInsightsTableParam as NuqsSetNullableValue<string>,
     setSchemaParam: setSchemaParam as NuqsSetNullableValue<string>,
     setSearchParam: setSearchParam as NuqsSetNullableValue<string>,
     setSearchScopeParam: setSearchScopeParam as NuqsSetNullableValue<string>,

--- a/ui/hooks/use-stream-events.test.tsx
+++ b/ui/hooks/use-stream-events.test.tsx
@@ -560,6 +560,50 @@ describe("useStreamEvents", () => {
     harness.cleanup();
   });
 
+  it("falls back to ts epoch fields for event timestamps", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            ts: 1_700_000_000_000,
+            value: {
+              id: "query-1",
+            },
+          },
+        ]),
+        {
+          headers: {
+            "content-type": "application/json",
+          },
+        },
+      ),
+    );
+    const harness = renderHarness({
+      pageCount: 1,
+      pageSize: 1,
+      stream: {
+        createdAt: "2026-03-24T14:42:38.890Z",
+        epoch: 0,
+        expiresAt: null,
+        name: "prisma-log",
+        nextOffset: "1",
+        sealedThrough: "-1",
+        uploadedThrough: "-1",
+      },
+      visibleEventCount: 1n,
+    });
+
+    await waitFor(() => harness.getLatestState()?.events.length === 1);
+
+    expect(harness.getLatestState()?.events[0]).toEqual(
+      expect.objectContaining({
+        exactTimestamp: "2023-11-14T22:13:20.000Z",
+      }),
+    );
+
+    harness.cleanup();
+  });
+
   it("keeps the last resolved event window visible while a larger tail window is fetching", async () => {
     let resolveSecondFetch: ((response: Response) => void) | undefined;
     const fetchSpy = vi

--- a/ui/hooks/use-stream-events.ts
+++ b/ui/hooks/use-stream-events.ts
@@ -349,6 +349,7 @@ function extractExactTimestamp(
     headers?.timestamp,
     value.timestamp,
     value.time,
+    value.ts,
     value.createdAt,
     value.created_at,
     value.occurredAt,

--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -1,4 +1,8 @@
-export { Studio, type StudioProps } from "./studio/Studio";
+export {
+  Studio,
+  type StudioProps,
+  type StudioQueryInsights,
+} from "./studio/Studio";
 export {
   type CustomTheme,
   type ThemeVariables,

--- a/ui/studio/CommandPalette.test.tsx
+++ b/ui/studio/CommandPalette.test.tsx
@@ -20,7 +20,7 @@ interface NavigationMockValue {
   schemaParam: string;
   setSchemaParam: () => Promise<URLSearchParams>;
   setTableParam: () => Promise<URLSearchParams>;
-  viewParam: "table" | "schema" | "console" | "sql";
+  viewParam: "console" | "query-insights" | "schema" | "sql" | "table";
 }
 
 interface IntrospectionMockValue {
@@ -36,6 +36,8 @@ const toggleNavigationMock = vi.fn();
 const setThemeModeMock = vi.fn();
 let isNavigationOpen = true;
 let isDarkMode = false;
+let hasDatabase = true;
+let queryInsightsTransport: unknown;
 let themeMode: "dark" | "light" | "system" = "system";
 const uiStateStore = new Map<string, unknown>();
 const uiStateListeners = new Map<string, Set<() => void>>();
@@ -150,8 +152,10 @@ vi.mock("../hooks/use-ui-state", async () => {
 
 vi.mock("./context", () => ({
   useStudio: () => ({
+    hasDatabase,
     isDarkMode,
     isNavigationOpen,
+    queryInsights: queryInsightsTransport,
     setThemeMode: setThemeModeMock,
     themeMode,
     toggleNavigation: toggleNavigationMock,
@@ -290,6 +294,8 @@ describe("Studio command palette", () => {
     });
     isNavigationOpen = true;
     isDarkMode = false;
+    hasDatabase = true;
+    queryInsightsTransport = undefined;
     themeMode = "system";
     setThemeModeMock.mockReset();
     toggleNavigationMock.mockReset();
@@ -303,6 +309,8 @@ describe("Studio command palette", () => {
     window.location.hash = "";
     isNavigationOpen = true;
     isDarkMode = false;
+    hasDatabase = true;
+    queryInsightsTransport = undefined;
     themeMode = "system";
     HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     uiStateStore.clear();
@@ -352,11 +360,47 @@ describe("Studio command palette", () => {
     expect(document.body.textContent).not.toContain("incidents");
     expect(document.body.textContent).toContain("Visualizer");
     expect(document.body.textContent).toContain("Console");
+    expect(document.body.textContent).not.toContain("Query Insights");
     expect(document.body.textContent).toContain("SQL");
     expect(document.body.textContent).toContain("Studio theme");
     expect(document.body.textContent).toContain("Light");
     expect(document.body.textContent).toContain("Dark");
     expect(document.body.textContent).toContain("Match system theme");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("shows Query Insights in navigation commands only when configured", () => {
+    queryInsightsTransport = {};
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<StudioCommandPaletteProvider />);
+    });
+
+    act(() => {
+      keyDown("k", { metaKey: true });
+    });
+
+    const item = getCommandItemByText("Query Insights");
+
+    expect(item).toBeDefined();
+
+    act(() => {
+      item?.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(window.location.hash).toBe("#viewParam=query-insights");
 
     act(() => {
       root.unmount();

--- a/ui/studio/CommandPalette.tsx
+++ b/ui/studio/CommandPalette.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import {
   BetweenVerticalStart,
+  ChartNoAxesColumnIncreasing,
   Database,
   FileCode2,
   GalleryVerticalEnd,
@@ -164,7 +165,9 @@ function AppearanceCommandItem(props: {
       value={value}
       className={cn(
         "justify-between gap-3",
-        disabled ? "text-muted-foreground/55" : "text-foreground hover:bg-secondary/85",
+        disabled
+          ? "text-muted-foreground/55"
+          : "text-foreground hover:bg-secondary/85",
       )}
     >
       <span className="flex min-w-0 items-center gap-2.5">
@@ -334,7 +337,9 @@ export function StudioCommandPaletteProvider(props: PropsWithChildren) {
 function StudioCommandPalette() {
   const {
     isDarkMode,
+    hasDatabase,
     isNavigationOpen,
+    queryInsights,
     setThemeMode,
     themeMode,
     toggleNavigation,
@@ -508,6 +513,23 @@ function StudioCommandPalette() {
         },
         section: "views",
       },
+      ...(queryInsights && hasDatabase !== false
+        ? [
+            {
+              disabled: false,
+              icon: ChartNoAxesColumnIncreasing,
+              id: "view:query-insights",
+              keywords: ["query insights", "queries", "latency", "qps"],
+              label: "Query Insights",
+              onSelect: () => {
+                window.location.hash = createUrl({
+                  viewParam: "query-insights",
+                });
+              },
+              section: "views" as const,
+            },
+          ]
+        : []),
       {
         disabled: false,
         icon: FileCode2,
@@ -528,7 +550,7 @@ function StudioCommandPalette() {
         query,
       }),
     );
-  }, [createUrl, query]);
+  }, [createUrl, hasDatabase, query, queryInsights]);
   useEffect(() => {
     if (!isOpen) {
       setQuery("");

--- a/ui/studio/Navigation.test.tsx
+++ b/ui/studio/Navigation.test.tsx
@@ -17,7 +17,13 @@ interface NavigationMockValue {
   setSchemaParam: () => Promise<URLSearchParams>;
   setTableParam: () => Promise<URLSearchParams>;
   streamParam: string | null;
-  viewParam: "table" | "schema" | "console" | "sql" | "stream";
+  viewParam:
+    | "console"
+    | "query-insights"
+    | "schema"
+    | "sql"
+    | "stream"
+    | "table";
 }
 
 interface IntrospectionMockValue {
@@ -57,6 +63,7 @@ interface StudioMockValue {
   hasDatabase: boolean;
   isDarkMode: boolean;
   navigationWidth: number;
+  queryInsights?: unknown;
   setNavigationWidth: (width: number) => void;
 }
 
@@ -420,6 +427,56 @@ describe("Navigation", () => {
     expect(tableLink).not.toBeUndefined();
     expect(tableLink?.getAttribute("data-sidebar")).toBe("menu-button");
     expect(tableLink?.parentElement?.tagName).toBe("NAV");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("shows Query Insights navigation only when the transport is configured", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<Navigation />);
+    });
+
+    expect(container.textContent).not.toContain("Query Insights");
+
+    useStudioMock.mockImplementation(() => ({
+      hasDatabase: true,
+      isDarkMode,
+      navigationWidth: 192,
+      queryInsights: {},
+      setNavigationWidth: setNavigationWidthMock,
+    }));
+
+    act(() => {
+      root.render(<Navigation />);
+    });
+
+    const link = Array.from(container.querySelectorAll("a")).find(
+      (item) => item.textContent?.trim() === "Query Insights",
+    );
+
+    expect(link).toBeDefined();
+    expect(link?.getAttribute("href")).toBe("#viewParam=query-insights");
+
+    useStudioMock.mockImplementation(() => ({
+      hasDatabase: false,
+      isDarkMode,
+      navigationWidth: 192,
+      queryInsights: {},
+      setNavigationWidth: setNavigationWidthMock,
+    }));
+
+    act(() => {
+      root.render(<Navigation />);
+    });
+
+    expect(container.textContent).not.toContain("Query Insights");
 
     act(() => {
       root.unmount();

--- a/ui/studio/Navigation.tsx
+++ b/ui/studio/Navigation.tsx
@@ -41,8 +41,13 @@ type NavigationProps = {
 export function Navigation({ className }: NavigationProps) {
   const { metadata, createUrl, streamParam, viewParam, schemaParam } =
     useNavigation();
-  const { hasDatabase, isDarkMode, navigationWidth, setNavigationWidth } =
-    useStudio();
+  const {
+    hasDatabase,
+    isDarkMode,
+    navigationWidth,
+    queryInsights,
+    setNavigationWidth,
+  } = useStudio();
   const { isFetching, activeTable } = metadata;
   const { errorState, hasResolvedIntrospection, isRefetching, refetch } =
     useIntrospection();
@@ -526,6 +531,20 @@ export function Navigation({ className }: NavigationProps) {
                 Console
               </a>
             </Navigation.Item>
+            {queryInsights && hasDatabase ? (
+              <Navigation.Item
+                asChild
+                isActive={viewParam === "query-insights"}
+                className={navigationItemClasses}
+              >
+                <a
+                  href={createUrl({ viewParam: "query-insights" })}
+                  className="w-full"
+                >
+                  Query Insights
+                </a>
+              </Navigation.Item>
+            ) : null}
             <Navigation.Item
               asChild
               isActive={viewParam === "sql"}

--- a/ui/studio/Studio.test.tsx
+++ b/ui/studio/Studio.test.tsx
@@ -9,7 +9,7 @@ type NavigationMockValue = {
   metadata: {
     activeTable: undefined;
   };
-  viewParam: "table" | "stream";
+  viewParam: "query-insights" | "table" | "stream";
 };
 
 type IntrospectionMockValue = {
@@ -31,6 +31,7 @@ type IntrospectionMockValue = {
 type StudioMockValue = {
   hasDatabase: boolean;
   isNavigationOpen: boolean;
+  queryInsights?: unknown;
   streamsUrl?: string;
 };
 
@@ -81,6 +82,10 @@ vi.mock("./Navigation", () => ({
 
 vi.mock("./views/console/ConsoleView", () => ({
   ConsoleView: () => <div>Console view</div>,
+}));
+
+vi.mock("./views/query-insights/QueryInsightsView", () => ({
+  QueryInsightsView: () => <div>Query Insights view</div>,
 }));
 
 vi.mock("./views/schema/SchemaView", () => ({
@@ -245,6 +250,49 @@ describe("Studio", () => {
     expect(
       container.querySelector('[data-testid="studio-main-pane"]')?.className,
     ).not.toContain("self-start");
+
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders the query insights view when the transport-backed view is active", () => {
+    useStudioMock.mockReturnValue({
+      hasDatabase: true,
+      isNavigationOpen: true,
+      queryInsights: {},
+      streamsUrl: "/api/streams",
+    });
+    useNavigationMock.mockReturnValue({
+      metadata: {
+        activeTable: undefined,
+      },
+      viewParam: "query-insights",
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <Studio
+          adapter={
+            {
+              delete: vi.fn(),
+              introspect: vi.fn(),
+              insert: vi.fn(),
+              query: vi.fn(),
+              raw: vi.fn(),
+              update: vi.fn(),
+            } as unknown as Adapter
+          }
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("Query Insights view");
 
     act(() => {
       root.unmount();

--- a/ui/studio/Studio.tsx
+++ b/ui/studio/Studio.tsx
@@ -14,6 +14,12 @@ import { IntrospectionStatusNotice } from "./IntrospectionStatusNotice";
 import { Navigation } from "./Navigation";
 import { StudioHeader } from "./StudioHeader";
 import { ConsoleView } from "./views/console/ConsoleView";
+import { QueryInsightsView } from "./views/query-insights/QueryInsightsView";
+import type {
+  QueryInsightsAnalyzeInput,
+  QueryInsightsAnalyzeResponse,
+  QueryInsightsUiEvent,
+} from "./views/query-insights/types";
 import { SchemaView } from "./views/schema/SchemaView";
 import { SqlView } from "./views/sql/SqlView";
 import { StreamView } from "./views/stream/StreamView";
@@ -68,12 +74,23 @@ export interface StudioProps {
   hasDatabase?: boolean;
   llm?: StudioLlm;
   onEvent?: (error: StudioEvent) => void;
+  queryInsights?: StudioQueryInsights;
   streamsUrl?: string;
   /**
    * Custom theme configuration or CSS string from shadcn
    * Supports both parsed theme object and raw CSS string
    */
   theme?: CustomTheme | string;
+}
+
+export interface StudioQueryInsights {
+  aiRecommendationsEnabled: boolean;
+  analyze(
+    input: QueryInsightsAnalyzeInput,
+  ): Promise<QueryInsightsAnalyzeResponse>;
+  enableAiRecommendations(): Promise<{ ok: true }>;
+  onEvent?: (event: QueryInsightsUiEvent) => void;
+  streamUrl: string;
 }
 
 /**
@@ -85,6 +102,7 @@ export function Studio(props: StudioProps) {
     hasDatabase = true,
     llm,
     onEvent,
+    queryInsights,
     streamsUrl,
     theme,
   } = props;
@@ -100,6 +118,7 @@ export function Studio(props: StudioProps) {
       hasDatabase={hasDatabase}
       llm={llm}
       onEvent={onEvent}
+      queryInsights={queryInsights}
       streamsUrl={streamsUrl}
       theme={theme}
     >
@@ -111,6 +130,7 @@ export function Studio(props: StudioProps) {
 const views: Record<string, (props: ViewProps) => JSX.Element | null> = {
   schema: SchemaView,
   table: ActiveTableView,
+  "query-insights": QueryInsightsView,
   stream: StreamView,
   console: ConsoleView,
   sql: SqlView,

--- a/ui/studio/context.tsx
+++ b/ui/studio/context.tsx
@@ -35,7 +35,12 @@ import { createUrl, NavigationContextProvider } from "../hooks/use-navigation";
 import { CustomTheme, useTheme } from "../hooks/use-theme";
 import shortUUID from "../lib/short-uuid";
 import { NuqsHashAdapter } from "./NuqsHashAdapter";
-import { StudioEvent, StudioEventBase, StudioOperationEvent } from "./Studio";
+import {
+  StudioEvent,
+  StudioEventBase,
+  StudioOperationEvent,
+  type StudioQueryInsights,
+} from "./Studio";
 import { instrumentTanStackCollectionMutations } from "./tanstack-db-mutation-guard";
 
 declare const VERSION_INJECTED_AT_BUILD_TIME: string;
@@ -255,6 +260,7 @@ interface StudioContextValue {
   adapter: Adapter;
   hasDatabase: boolean;
   llm?: StudioLlm;
+  queryInsights?: StudioQueryInsights;
   streamsUrl?: string;
   hasAiFilter: boolean;
   hasAiSql: boolean;
@@ -298,6 +304,7 @@ export type StudioContextProviderProps = PropsWithChildren<{
   hasDatabase?: boolean;
   llm?: StudioLlm;
   onEvent?: (event: StudioEvent) => void;
+  queryInsights?: StudioQueryInsights;
   streamsUrl?: string;
   theme?: CustomTheme | string;
 }>;
@@ -309,6 +316,7 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
     adapter,
     hasDatabase = true,
     llm,
+    queryInsights,
     streamsUrl,
     theme,
   } = props;
@@ -823,6 +831,7 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
           adapter,
           hasDatabase,
           llm,
+          queryInsights,
           streamsUrl,
           hasAiFilter,
           hasAiSql,

--- a/ui/studio/tanstack-db-performance-architecture.test.ts
+++ b/ui/studio/tanstack-db-performance-architecture.test.ts
@@ -54,6 +54,7 @@ describe("TanStack DB architecture compliance", () => {
     expect(filesWithCreateCollection).toEqual(
       [
         "ui/hooks/use-active-table-rows-collection.ts",
+        "ui/hooks/use-stream-events.ts",
         "ui/hooks/use-ui-state.ts",
         "ui/studio/context.tsx",
       ].sort(),

--- a/ui/studio/views/query-insights/QueryInsightsChart.tsx
+++ b/ui/studio/views/query-insights/QueryInsightsChart.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/components/ui/card";
+
+import type { QueryInsightsChartPoint } from "./types";
+
+type ChartKind = "latency" | "qps";
+
+function formatMetric(
+  value: number,
+  kind: ChartKind,
+): {
+  unit: string;
+  value: string;
+} {
+  if (kind === "qps") {
+    return {
+      unit: "queries/sec",
+      value: value.toFixed(1),
+    };
+  }
+
+  if (value >= 1_000) {
+    return {
+      unit: "seconds",
+      value: (value / 1_000).toFixed(2),
+    };
+  }
+
+  if (value >= 1) {
+    return {
+      unit: "milliseconds",
+      value: value.toFixed(0),
+    };
+  }
+
+  return {
+    unit: "milliseconds",
+    value: value.toFixed(2),
+  };
+}
+
+function getCssVariable(name: string, fallback: string): string {
+  if (typeof window === "undefined") {
+    return fallback;
+  }
+
+  const value = window
+    .getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+
+  return value || fallback;
+}
+
+function getElementFontFamily(element: HTMLElement): string | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+
+  return window.getComputedStyle(element).fontFamily || undefined;
+}
+
+export function QueryInsightsChart(props: {
+  data: QueryInsightsChartPoint[];
+  kind: ChartKind;
+  loading?: boolean;
+  pollingIntervalMs?: number;
+  title: string;
+}) {
+  const {
+    data,
+    kind,
+    loading = false,
+    pollingIntervalMs = 1_000,
+    title,
+  } = props;
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const chartRef = useRef<{ destroy(): void } | null>(null);
+  const values = useMemo(() => {
+    if (kind === "qps") {
+      return data.map((point) =>
+        Number((point.queryCount / (pollingIntervalMs / 1_000)).toFixed(2)),
+      );
+    }
+
+    return data.map((point) => point.avgDurationMs);
+  }, [data, kind, pollingIntervalMs]);
+  const headlineValue = useMemo(() => {
+    if (kind === "qps") {
+      return values.at(-1) ?? 0;
+    }
+
+    const totalQueries = data.reduce(
+      (total, point) => total + point.queryCount,
+      0,
+    );
+
+    if (totalQueries === 0) {
+      return 0;
+    }
+
+    return (
+      data.reduce(
+        (total, point) => total + point.avgDurationMs * point.queryCount,
+        0,
+      ) / totalQueries
+    );
+  }, [data, kind, values]);
+  const headline = formatMetric(headlineValue, kind);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+
+    if (!canvas || loading) {
+      return;
+    }
+
+    const context = canvas.getContext("2d");
+
+    if (!context) {
+      return;
+    }
+
+    let isCanceled = false;
+
+    void import("chart.js/auto")
+      .then(({ default: Chart }) => {
+        if (isCanceled) {
+          return;
+        }
+
+        chartRef.current?.destroy();
+
+        const labels = data.map((point) =>
+          new Date(point.ts).toISOString().slice(11, 19),
+        );
+        const primary = getCssVariable(
+          "--primary",
+          "oklch(0.64 0.1423 268.56)",
+        );
+        const muted = getCssVariable(
+          "--muted-foreground",
+          "oklch(0.552 0.016 285.938)",
+        );
+        const border = getCssVariable("--border", "oklch(0.92 0.004 286.32)");
+        const fontFamily = getElementFontFamily(canvas);
+
+        chartRef.current = new Chart(context, {
+          data: {
+            datasets: [
+              {
+                ...(kind === "latency"
+                  ? {
+                      barPercentage: 0.7,
+                      categoryPercentage: 0.75,
+                      maxBarThickness: 48,
+                    }
+                  : {
+                      pointHitRadius: 8,
+                      pointHoverRadius: 4,
+                    }),
+                backgroundColor: kind === "latency" ? primary : "transparent",
+                borderColor: primary,
+                borderWidth: 2,
+                data: values,
+                fill: false,
+                pointRadius: kind === "qps" ? 2 : 0,
+                tension: 0.2,
+              },
+            ],
+            labels,
+          },
+          options: {
+            animation: false,
+            font: {
+              family: fontFamily,
+              size: 11,
+            },
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label(context) {
+                    const value = Number(context.parsed.y ?? 0);
+                    return kind === "qps"
+                      ? `${value.toFixed(1)} QPS`
+                      : `${value.toFixed(2)}ms`;
+                  },
+                },
+              },
+            },
+            scales: {
+              x: {
+                display: false,
+                grid: { display: false },
+              },
+              y: {
+                beginAtZero: true,
+                border: { display: false },
+                grid: { color: border },
+                ticks: {
+                  color: muted,
+                  maxTicksLimit: 3,
+                },
+              },
+            },
+          },
+          type: kind === "latency" ? "bar" : "line",
+        });
+      })
+      .catch(() => undefined);
+
+    return () => {
+      isCanceled = true;
+      chartRef.current?.destroy();
+      chartRef.current = null;
+    };
+  }, [data, kind, loading, values]);
+
+  return (
+    <Card className="min-h-0 rounded-md border-border bg-card shadow-none">
+      <CardHeader className="flex-row items-start justify-between gap-3 p-4">
+        <div className="flex min-w-0 flex-col gap-1">
+          <CardTitle className="text-sm font-medium leading-5 tracking-normal">
+            {title}
+          </CardTitle>
+          <CardDescription className="text-xs">{headline.unit}</CardDescription>
+        </div>
+        <div className="text-xl font-semibold leading-none tabular-nums">
+          {headline.value}
+        </div>
+      </CardHeader>
+      <CardContent className="h-32 p-4 pt-0">
+        {loading ? (
+          <div className="h-full rounded-md bg-muted" />
+        ) : (
+          <canvas
+            aria-label={`${title} chart`}
+            className="h-full w-full"
+            ref={canvasRef}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/studio/views/query-insights/QueryInsightsView.test.tsx
+++ b/ui/studio/views/query-insights/QueryInsightsView.test.tsx
@@ -1,0 +1,197 @@
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QueryInsightsView } from "./QueryInsightsView";
+import type { QueryInsightsQuery } from "./types";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const {
+  analyzeMock,
+  pauseMock,
+  queryInsightsMock,
+  queryRowsState,
+  resumeMock,
+  setQueryInsightsSortParamMock,
+  setQueryInsightsTableParamMock,
+} = vi.hoisted(() => ({
+  ...(() => {
+    const analyzeMock = vi.fn();
+    const enableAiRecommendationsMock = vi.fn();
+    const queryInsightsMock = {
+      aiRecommendationsEnabled: true,
+      analyze: analyzeMock,
+      enableAiRecommendations: enableAiRecommendationsMock,
+      onEvent: vi.fn(),
+      streamUrl: "/api/query-insights",
+    };
+
+    return {
+      analyzeMock,
+      enableAiRecommendationsMock,
+      pauseMock: vi.fn(),
+      queryInsightsMock,
+      queryRowsState: {
+        queries: [] as QueryInsightsQuery[],
+      },
+      resumeMock: vi.fn(),
+      setQueryInsightsSortParamMock: vi.fn(),
+      setQueryInsightsTableParamMock: vi.fn(),
+    };
+  })(),
+}));
+
+vi.mock("../../context", () => ({
+  useStudio: () => ({
+    hasDatabase: true,
+    isNavigationOpen: true,
+    queryInsights: queryInsightsMock,
+    toggleNavigation: vi.fn(),
+  }),
+}));
+
+vi.mock("../../StudioHeader", () => ({
+  StudioHeader: ({
+    children,
+    endContent,
+  }: {
+    children?: ReactNode;
+    endContent?: ReactNode;
+  }) => (
+    <div>
+      {children}
+      {endContent}
+    </div>
+  ),
+}));
+
+vi.mock("@/ui/hooks/use-navigation", () => ({
+  useNavigation: () => ({
+    queryInsightsSortParam: null,
+    queryInsightsTableParam: null,
+    setQueryInsightsSortParam: setQueryInsightsSortParamMock,
+    setQueryInsightsTableParam: setQueryInsightsTableParamMock,
+  }),
+}));
+
+vi.mock("./use-query-insights-stream", () => ({
+  useQueryInsightsStream: () => ({ status: "open" }),
+}));
+
+vi.mock("./use-query-insights-rows", () => ({
+  useQueryInsightsRows: () => ({
+    flushedIds: new Set<string>(),
+    ingestQueries: vi.fn(),
+    isAtLimit: false,
+    isPaused: false,
+    pause: pauseMock,
+    pauseBufferSize: 0,
+    queries: queryRowsState.queries,
+    recentlyAddedIds: new Set<string>(),
+    resume: resumeMock,
+  }),
+}));
+
+function createQuery(overrides: Partial<QueryInsightsQuery> = {}) {
+  return {
+    count: 281,
+    duration: 0,
+    groupKey: null,
+    id: "query-1",
+    lastSeen: 1_700_000_000_000,
+    maxDurationMs: 0,
+    minDurationMs: 0,
+    prismaQueryInfo: null,
+    query:
+      "WITH state_mapping AS ( SELECT CASE WHEN state = 'active' AND wait_event_type IS NULL THEN 'active' WHEN state = 'active' AND wait_event_type IS NOT NULL THEN 'waiting' END AS state FROM pg_stat_activity ) SELECT * FROM state_mapping",
+    queryId: null,
+    reads: 3,
+    rowsReturned: 42,
+    tables: ["state_mapping"],
+    ...overrides,
+  } satisfies QueryInsightsQuery;
+}
+
+describe("QueryInsightsView", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    queryRowsState.queries = [createQuery()];
+    analyzeMock.mockResolvedValue({
+      error: null,
+      result: {
+        analysisMarkdown:
+          "## Problem\nThe query scans more rows than needed.\n\n## Why it matters\nExtra reads can slow down interactive workflows.",
+        improvedSql: "CREATE INDEX state_mapping_idx ON state_mapping (state);",
+        isOptimal: false,
+        issuesFound: ["Sequential scan"],
+        recommendations: ["Adding an index could reduce reads by 80%."],
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("opens the original right-side AI drawer for a selected query", async () => {
+    const container = document.createElement("div");
+    container.className = "ps";
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<QueryInsightsView />);
+    });
+
+    const tableFrame = container.querySelector<HTMLElement>(
+      '[data-testid="query-insights-table"]',
+    )?.parentElement;
+
+    expect(tableFrame?.className).toContain("border-transparent");
+    expect(tableFrame?.className).toContain("rounded-sm");
+    expect(tableFrame?.className).toContain("after:border-border");
+
+    const queryRow = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="button"]'),
+    ).find((element) => element.textContent?.includes("WITH state_mapping"));
+
+    expect(queryRow).not.toBeUndefined();
+
+    act(() => {
+      queryRow?.click();
+    });
+
+    const dialog = document.body.querySelector<HTMLElement>('[role="dialog"]');
+
+    expect(dialog?.className).toContain("right-2");
+    expect(dialog?.className).toContain("rounded-xl");
+    expect(container.contains(dialog)).toBe(true);
+    expect(document.body.textContent).toContain(
+      "This SQL query reads from state_mapping.",
+    );
+    expect(document.body.textContent).toContain("Show full query");
+    expect(document.body.textContent).toContain("Analyzing query...");
+    expect(pauseMock).toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    expect(document.body.textContent).toContain("Recommendations");
+    expect(document.body.textContent).not.toContain("## Problem");
+    expect(document.body.textContent).toContain(
+      "Extra reads can slow down interactive workflows.",
+    );
+    expect(document.body.textContent).toContain(
+      "Adding an index could reduce reads by 80%.",
+    );
+    expect(
+      document.body.querySelector<HTMLElement>(".text-primary")?.textContent,
+    ).toBe("80%");
+  });
+});

--- a/ui/studio/views/query-insights/QueryInsightsView.tsx
+++ b/ui/studio/views/query-insights/QueryInsightsView.tsx
@@ -1,0 +1,1514 @@
+import {
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  DatabaseZap,
+  Loader2,
+  Pause,
+  Play,
+  SearchX,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { Badge } from "@/ui/components/ui/badge";
+import { Button } from "@/ui/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/ui/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/ui/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/ui/components/ui/table";
+import { useNavigation } from "@/ui/hooks/use-navigation";
+import { cn } from "@/ui/lib/utils";
+
+import { useStudio } from "../../context";
+import { StudioHeader } from "../../StudioHeader";
+import { QueryInsightsChart } from "./QueryInsightsChart";
+import {
+  buildQueryInsightsDisplayRows,
+  filterQueryInsightsByTable,
+  getAvailableQueryInsightTables,
+} from "./rows";
+import {
+  QUERY_INSIGHTS_CHART_BUFFER_LIMIT,
+  QUERY_INSIGHTS_DEFAULT_SORT,
+  QUERY_INSIGHTS_MAX_QUERIES,
+  type QueryInsightsAnalysisResult,
+  type QueryInsightsAnalyzeInput,
+  type QueryInsightsChartPoint,
+  type QueryInsightsDisplayRow,
+  type QueryInsightsGroup,
+  type QueryInsightsQuery,
+  type QueryInsightsSortDirection,
+  type QueryInsightsSortField,
+  type QueryInsightsSortState,
+} from "./types";
+import { useQueryInsightsRows } from "./use-query-insights-rows";
+import { useQueryInsightsStream } from "./use-query-insights-stream";
+
+const SORT_OPTIONS: Array<{ label: string; value: string }> = [
+  { label: "Reads, high to low", value: "reads:desc" },
+  { label: "Reads, low to high", value: "reads:asc" },
+  { label: "Latency, high to low", value: "latency:desc" },
+  { label: "Latency, low to high", value: "latency:asc" },
+  { label: "Executions, high to low", value: "executions:desc" },
+  { label: "Executions, low to high", value: "executions:asc" },
+  { label: "Last seen, newest", value: "lastSeen:desc" },
+  { label: "Last seen, oldest", value: "lastSeen:asc" },
+];
+const ALL_TABLES_VALUE = "__all__";
+
+function parseSortParam(
+  value: string | null | undefined,
+): QueryInsightsSortState {
+  if (!value) {
+    return QUERY_INSIGHTS_DEFAULT_SORT;
+  }
+
+  const [field, direction] = value.split(":") as [
+    QueryInsightsSortField | undefined,
+    QueryInsightsSortDirection | undefined,
+  ];
+
+  if (
+    (field === "latency" ||
+      field === "reads" ||
+      field === "executions" ||
+      field === "lastSeen") &&
+    (direction === "asc" || direction === "desc")
+  ) {
+    return { direction, field };
+  }
+
+  return QUERY_INSIGHTS_DEFAULT_SORT;
+}
+
+function serializeSort(sort: QueryInsightsSortState): string {
+  return `${sort.field}:${sort.direction}`;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 1,
+    notation: value >= 10_000 ? "compact" : "standard",
+  }).format(value);
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1) {
+    return "< 1ms";
+  }
+
+  if (ms >= 1_000) {
+    return `${(ms / 1_000).toFixed(2)}s`;
+  }
+
+  return `${ms.toFixed(0)}ms`;
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function mergeChartPoints(
+  existing: QueryInsightsChartPoint,
+  incoming: QueryInsightsChartPoint,
+): QueryInsightsChartPoint {
+  const queryCount = existing.queryCount + incoming.queryCount;
+
+  return {
+    avgDurationMs:
+      queryCount > 0
+        ? (existing.avgDurationMs * existing.queryCount +
+            incoming.avgDurationMs * incoming.queryCount) /
+          queryCount
+        : 0,
+    queryCount,
+    ts: existing.ts,
+  };
+}
+
+function formatTableList(tables: string[]): string {
+  if (tables.length === 0) {
+    return "unknown tables";
+  }
+
+  if (tables.length === 1) {
+    return tables[0] ?? "unknown table";
+  }
+
+  return `${tables.slice(0, -1).join(", ")} and ${tables.at(-1)}`;
+}
+
+function getRowKey(row: QueryInsightsDisplayRow): string {
+  return row.type === "group"
+    ? `group:${row.group.groupKey}`
+    : `query:${row.query.id}`;
+}
+
+function getRowLabel(row: QueryInsightsDisplayRow): string {
+  if (row.type === "group") {
+    const { prismaQueryInfo } = row.group;
+    return `${prismaQueryInfo.model ? `${prismaQueryInfo.model}.` : ""}${prismaQueryInfo.action}()`;
+  }
+
+  const { prismaQueryInfo } = row.query;
+
+  if (prismaQueryInfo && !prismaQueryInfo.isRaw) {
+    return `${prismaQueryInfo.model ? `${prismaQueryInfo.model}.` : ""}${prismaQueryInfo.action}()`;
+  }
+
+  return row.query.query;
+}
+
+function rowMatchesKey(
+  row: QueryInsightsDisplayRow,
+  key: string | null,
+): boolean {
+  return key !== null && getRowKey(row) === key;
+}
+
+function getRowMetrics(row: QueryInsightsDisplayRow) {
+  if (row.type === "group") {
+    return {
+      count: row.group.totalCount,
+      duration: row.group.avgDuration,
+      lastSeen: row.group.lastSeen,
+      reads: row.group.totalReads,
+      rowsReturned: row.group.totalRows,
+      tables: row.group.tables,
+    };
+  }
+
+  return {
+    count: row.query.count,
+    duration: row.query.duration,
+    lastSeen: row.query.lastSeen,
+    reads: row.query.reads,
+    rowsReturned: row.query.rowsReturned,
+    tables: row.query.tables,
+  };
+}
+
+function PrismaOperationCode(props: {
+  info: NonNullable<QueryInsightsQuery["prismaQueryInfo"]>;
+}) {
+  const { info } = props;
+
+  return (
+    <code className="block truncate font-mono text-xs">
+      {info.model ? `${info.model}.` : ""}
+      <span className="font-semibold text-foreground">{info.action}</span>
+      {info.payload ? `(${JSON.stringify(info.payload)})` : "()"}
+    </code>
+  );
+}
+
+function QueryLabel(props: { row: QueryInsightsDisplayRow }) {
+  const { row } = props;
+
+  if (row.type === "group") {
+    return (
+      <div className="flex min-w-0 flex-col gap-1">
+        <PrismaOperationCode info={row.group.prismaQueryInfo} />
+        <span className="truncate text-xs text-muted-foreground">
+          {row.group.children.length} SQL statements
+        </span>
+      </div>
+    );
+  }
+
+  if (row.query.prismaQueryInfo && !row.query.prismaQueryInfo.isRaw) {
+    return (
+      <div className="flex min-w-0 flex-col gap-1">
+        <PrismaOperationCode info={row.query.prismaQueryInfo} />
+        <span className="truncate font-mono text-xs text-muted-foreground">
+          {row.query.query}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <code className="block truncate font-mono text-xs">{row.query.query}</code>
+  );
+}
+
+function QueryInsightsTable(props: {
+  displayRows: QueryInsightsDisplayRow[];
+  flushedIds: Set<string>;
+  isAtLimit: boolean;
+  isPaused: boolean;
+  onSelectRow: (row: QueryInsightsDisplayRow) => void;
+  pauseBufferSize: number;
+  recentlyAddedIds: Set<string>;
+  selectedRowKey: string | null;
+  sort: QueryInsightsSortState;
+}) {
+  const {
+    displayRows,
+    flushedIds,
+    isAtLimit,
+    isPaused,
+    onSelectRow,
+    pauseBufferSize,
+    recentlyAddedIds,
+    selectedRowKey,
+    sort,
+  } = props;
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-sm border border-transparent bg-background after:pointer-events-none after:absolute after:inset-0 after:z-20 after:rounded-sm after:border after:border-border">
+      {isAtLimit ? (
+        <div className="border-b border-border bg-muted/45 px-3 py-2 text-xs text-muted-foreground">
+          Showing the latest {formatNumber(QUERY_INSIGHTS_MAX_QUERIES)} unique
+          query patterns.
+        </div>
+      ) : null}
+      {isPaused && pauseBufferSize > 0 ? (
+        <div className="border-b border-border bg-muted/45 px-3 py-2 text-xs text-muted-foreground">
+          Recorded {formatNumber(pauseBufferSize)} recent{" "}
+          {pauseBufferSize === 1 ? "query" : "queries"} while paused.
+        </div>
+      ) : null}
+      <Table
+        className="min-w-[42rem] table-fixed"
+        containerProps={{
+          className: "relative min-h-0 flex-1 overflow-auto",
+          "data-testid": "query-insights-table",
+        }}
+      >
+        <TableHeader className="sticky top-0 z-10 bg-background/95 backdrop-blur-sm">
+          <TableRow className="border-border hover:bg-background">
+            <TableHead className="h-9 w-28 px-3 text-xs">Latency</TableHead>
+            <TableHead className="h-9 px-3 text-xs">Query</TableHead>
+            <TableHead className="h-9 w-28 px-3 text-right text-xs">
+              Executions
+            </TableHead>
+            <TableHead className="h-9 w-24 px-3 text-right text-xs">
+              Reads
+            </TableHead>
+            <TableHead className="h-9 w-28 px-3 text-right text-xs">
+              Last Seen
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {displayRows.map((row) => {
+            const key = getRowKey(row);
+            const metrics = getRowMetrics(row);
+            const isSelected = key === selectedRowKey;
+            const queryIds =
+              row.type === "group"
+                ? row.group.children.map((query) => query.id)
+                : [row.query.id];
+            const isFlushed = queryIds.some((id) => flushedIds.has(id));
+            const isNew = queryIds.some((id) => recentlyAddedIds.has(id));
+
+            return (
+              <TableRow
+                aria-label={getRowLabel(row)}
+                className={cn(
+                  "cursor-pointer border-border focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                  isSelected && "bg-muted",
+                  isFlushed && "bg-primary/10",
+                  isNew && "bg-primary/5",
+                )}
+                data-state={isSelected ? "selected" : undefined}
+                key={key}
+                onClick={() => onSelectRow(row)}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") {
+                    return;
+                  }
+
+                  event.preventDefault();
+                  onSelectRow(row);
+                }}
+                role="button"
+                tabIndex={0}
+              >
+                <TableCell className="px-3 py-2">
+                  <Badge
+                    className="font-medium tabular-nums"
+                    variant={
+                      metrics.duration >= 500
+                        ? "destructive"
+                        : metrics.duration >= 100
+                          ? "secondary"
+                          : "success"
+                    }
+                  >
+                    {formatLatency(metrics.duration)}
+                  </Badge>
+                </TableCell>
+                <TableCell className="min-w-0 px-3 py-2">
+                  <QueryLabel row={row} />
+                </TableCell>
+                <TableCell
+                  className={cn(
+                    "px-3 py-2 text-right font-mono text-xs",
+                    sort.field === "executions" && "text-foreground",
+                  )}
+                >
+                  {formatNumber(metrics.count)}
+                </TableCell>
+                <TableCell
+                  className={cn(
+                    "px-3 py-2 text-right font-mono text-xs",
+                    sort.field === "reads" && "text-foreground",
+                  )}
+                >
+                  {metrics.reads > 0 ? formatNumber(metrics.reads) : "-"}
+                </TableCell>
+                <TableCell
+                  className={cn(
+                    "px-3 py-2 text-right font-mono text-xs",
+                    sort.field === "lastSeen" && "text-foreground",
+                  )}
+                >
+                  {formatTime(metrics.lastSeen)}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function CopyButton(props: {
+  className?: string;
+  label: string;
+  onCopied?: () => void;
+  text: string;
+}) {
+  const { className, label, onCopied, text } = props;
+
+  return (
+    <Button
+      aria-label={label}
+      className={className}
+      onClick={() => {
+        void (navigator.clipboard?.writeText(text) ?? Promise.resolve()).then(
+          () => onCopied?.(),
+        );
+      }}
+      size="icon"
+      type="button"
+      variant="outline"
+    >
+      <Copy data-icon="inline-start" />
+    </Button>
+  );
+}
+
+function EmbeddedCodeBlock(props: {
+  children: string;
+  language: "sql" | "text" | "ts";
+  lineClamp?: number;
+  onCopied?: () => void;
+}) {
+  const { children, language, lineClamp, onCopied } = props;
+  const clampStyle =
+    lineClamp != null
+      ? ({
+          WebkitBoxOrient: "vertical",
+          WebkitLineClamp: lineClamp,
+          display: "-webkit-box",
+        } as const)
+      : undefined;
+
+  return (
+    <div className="relative overflow-hidden rounded-md border border-border bg-muted/30">
+      <CopyButton
+        className="absolute right-3 top-3 z-10 size-7 bg-background/90 shadow-none"
+        label={`Copy ${language}`}
+        onCopied={onCopied}
+        text={children}
+      />
+      <pre
+        className="overflow-auto whitespace-pre-wrap break-words p-4 pr-12 font-mono text-sm leading-6 text-foreground"
+        style={clampStyle}
+      >
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+function buildAnalysisInput(
+  selectedRow: QueryInsightsDisplayRow,
+): QueryInsightsAnalyzeInput {
+  const target =
+    selectedRow.type === "group"
+      ? selectedRow.group.children[0]
+      : selectedRow.query;
+
+  return {
+    explainPlan: null,
+    groupChildren:
+      selectedRow.type === "group"
+        ? selectedRow.group.children.map((child) => ({
+            queryStats: {
+              count: child.count,
+              duration: child.duration,
+              reads: child.reads,
+              rowsReturned: child.rowsReturned,
+            },
+            rawQuery: child.query,
+          }))
+        : null,
+    prismaQueryInfo: target?.prismaQueryInfo
+      ? JSON.stringify(target.prismaQueryInfo)
+      : null,
+    queryStats: target
+      ? {
+          count: target.count,
+          duration: target.duration,
+          reads: target.reads,
+          rowsReturned: target.rowsReturned,
+        }
+      : null,
+    rawQuery: target?.query ?? "",
+  };
+}
+
+function useQueryInsightsAnalysis(selectedRow: QueryInsightsDisplayRow | null) {
+  const { queryInsights } = useStudio();
+  const [isAiEnabled, setIsAiEnabled] = useState(
+    () => queryInsights?.aiRecommendationsEnabled === true,
+  );
+  const [isEnabling, setIsEnabling] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [analysis, setAnalysis] = useState<QueryInsightsAnalysisResult | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    if (queryInsights?.aiRecommendationsEnabled) {
+      setIsAiEnabled(true);
+    }
+  }, [queryInsights?.aiRecommendationsEnabled]);
+
+  useEffect(() => {
+    setAnalysis(null);
+    setError(null);
+
+    if (!selectedRow || !queryInsights || !isAiEnabled) {
+      setIsAnalyzing(false);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsAnalyzing(true);
+
+    const timer = setTimeout(() => {
+      void queryInsights
+        .analyze(buildAnalysisInput(selectedRow))
+        .then((response) => {
+          if (requestIdRef.current !== requestId) {
+            return;
+          }
+
+          setAnalysis(response.result);
+          setError(response.error ?? null);
+        })
+        .catch((error: unknown) => {
+          if (requestIdRef.current !== requestId) {
+            return;
+          }
+
+          setError(error instanceof Error ? error.message : String(error));
+        })
+        .finally(() => {
+          if (requestIdRef.current === requestId) {
+            setIsAnalyzing(false);
+          }
+        });
+    }, 300);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [isAiEnabled, queryInsights, selectedRow]);
+
+  const enable = useCallback(async () => {
+    if (!queryInsights) {
+      return;
+    }
+
+    setIsEnabling(true);
+    setError(null);
+
+    try {
+      await queryInsights.enableAiRecommendations();
+      setIsAiEnabled(true);
+      queryInsights.onEvent?.({
+        name: "studio:query_insights:ai_consent_accepted",
+      });
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error));
+      setIsAiEnabled(false);
+    } finally {
+      setIsEnabling(false);
+    }
+  }, [queryInsights]);
+
+  return {
+    analysis,
+    enable,
+    error,
+    isAiEnabled,
+    isAnalyzing,
+    isEnabling,
+  };
+}
+
+function ProseSummary(props: { row: QueryInsightsDisplayRow }) {
+  const { row } = props;
+  const metrics = getRowMetrics(row);
+  const tableText =
+    metrics.tables.length > 0 ? formatTableList(metrics.tables) : null;
+
+  if (row.type === "group") {
+    return (
+      <div className="flex flex-col gap-2">
+        <p className="m-0 text-base leading-7 text-foreground">
+          This Prisma ORM call had an average total latency of{" "}
+          <span className="font-medium">{formatLatency(metrics.duration)}</span>
+          , with a minimum of{" "}
+          <span className="font-medium">
+            {formatLatency(row.group.minDuration)}
+          </span>{" "}
+          and a maximum of{" "}
+          <span className="font-medium">
+            {formatLatency(row.group.maxDuration)}
+          </span>
+          .
+        </p>
+        <p className="m-0 text-base leading-7 text-foreground">
+          The call generated{" "}
+          <span className="font-medium">
+            {row.group.children.length} SQL{" "}
+            {row.group.children.length === 1 ? "query" : "queries"}
+          </span>
+          {tableText
+            ? ` that read from ${tableText} ${
+                metrics.tables.length === 1 ? "table" : "tables"
+              }`
+            : ""}{" "}
+          with a total of{" "}
+          <span className="font-medium">
+            {formatNumber(row.group.totalRows)}
+          </span>{" "}
+          rows. It has been executed{" "}
+          <span className="font-medium">{formatNumber(metrics.count)}</span>{" "}
+          times in this session.
+        </p>
+      </div>
+    );
+  }
+
+  const { prismaQueryInfo } = row.query;
+  const isPrisma = prismaQueryInfo && !prismaQueryInfo.isRaw;
+
+  return (
+    <p className="m-0 text-base leading-7 text-foreground">
+      {isPrisma ? (
+        <>
+          This{" "}
+          <code className="rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-sm">
+            {prismaQueryInfo.model ? `${prismaQueryInfo.model}.` : ""}
+            {prismaQueryInfo.action}()
+          </code>{" "}
+          Prisma operation
+          {tableText
+            ? ` reads from ${tableText} ${
+                metrics.tables.length === 1 ? "table" : "tables"
+              }`
+            : ""}
+          .
+        </>
+      ) : (
+        <>This SQL query{tableText ? ` reads from ${tableText}` : ""}.</>
+      )}{" "}
+      It has been executed{" "}
+      <span className="font-medium">{formatNumber(metrics.count)}</span> times,
+      averaging{" "}
+      <span className="font-medium">{formatLatency(metrics.duration)}</span>{" "}
+      latency and{" "}
+      <span className="font-medium">{formatNumber(metrics.reads)}</span> block
+      reads per call.
+    </p>
+  );
+}
+
+const SQL_LINE_CLAMP = 4;
+const SQL_LENGTH_THRESHOLD = 160;
+
+function CollapsibleSqlBlock(props: {
+  onCopied: () => void;
+  query: QueryInsightsQuery;
+}) {
+  const { onCopied, query } = props;
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [query.id]);
+
+  const isLong =
+    query.query.split("\n").length > SQL_LINE_CLAMP ||
+    query.query.length > SQL_LENGTH_THRESHOLD;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <EmbeddedCodeBlock
+        language="sql"
+        lineClamp={!isExpanded && isLong ? SQL_LINE_CLAMP : undefined}
+        onCopied={onCopied}
+      >
+        {query.query}
+      </EmbeddedCodeBlock>
+      {isLong ? (
+        <Button
+          className="h-auto w-fit p-0 text-sm font-normal text-muted-foreground shadow-none hover:bg-transparent hover:text-foreground"
+          onClick={() => setIsExpanded((current) => !current)}
+          type="button"
+          variant="ghost"
+        >
+          {isExpanded ? "Collapse query" : "Show full query"}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function renderMarkdownText(text: string) {
+  const blocks: Array<{
+    text: string;
+    type: "heading" | "paragraph";
+  }> = [];
+  let paragraphLines: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) {
+      return;
+    }
+
+    blocks.push({
+      text: paragraphLines.join(" ").replace(/\*\*/g, ""),
+      type: "paragraph",
+    });
+    paragraphLines = [];
+  };
+
+  for (const line of text.split("\n")) {
+    const trimmedLine = line.trim();
+
+    if (!trimmedLine) {
+      flushParagraph();
+      continue;
+    }
+
+    const heading = /^(#{1,3})\s+(.+)$/.exec(trimmedLine);
+
+    if (heading) {
+      flushParagraph();
+      blocks.push({
+        text: heading[2] ?? trimmedLine,
+        type: "heading",
+      });
+      continue;
+    }
+
+    paragraphLines.push(trimmedLine);
+  }
+
+  flushParagraph();
+
+  return blocks;
+}
+
+function buildRecommendationPrompt(
+  recommendation: string,
+  query: QueryInsightsQuery,
+): string {
+  const context =
+    query.prismaQueryInfo && !query.prismaQueryInfo.isRaw
+      ? `${query.prismaQueryInfo.model ? `${query.prismaQueryInfo.model}.` : ""}${query.prismaQueryInfo.action}()`
+      : null;
+  const parts = [
+    context
+      ? `My Prisma query (${context}) has a performance issue:`
+      : "My query has a performance issue:",
+    "",
+    recommendation,
+    "",
+    `Query stats: avg latency ${formatLatency(query.duration)}, ${formatNumber(
+      query.reads,
+    )} block reads, ${formatNumber(query.rowsReturned)} rows returned.`,
+    "",
+    "SQL:",
+    query.query,
+    "",
+    "Please help me fix this issue. Show the solution in both SQL and Prisma schema.prisma syntax where applicable.",
+  ];
+
+  return parts.join("\n");
+}
+
+function HighlightedText(props: { text: string }) {
+  const parts = props.text.split(/(\d+(?:\.\d+)?%)/g);
+
+  return (
+    <p className="m-0 text-base leading-7 text-foreground">
+      {parts.map((part, index) =>
+        /^\d+(?:\.\d+)?%$/.test(part) ? (
+          <span className="font-semibold text-primary" key={index}>
+            {part}
+          </span>
+        ) : (
+          part
+        ),
+      )}
+    </p>
+  );
+}
+
+type RecommendationOutputTab = "prisma" | "prompt" | "sql";
+
+function RecommendationBlock(props: {
+  improvedPrisma?: string;
+  improvedSql?: string;
+  onCopied: (tab: "ai-prompt" | "prisma" | "sql") => void;
+  query: QueryInsightsQuery;
+  recommendation: string;
+}) {
+  const { improvedPrisma, improvedSql, onCopied, query, recommendation } =
+    props;
+  const [tab, setTab] = useState<RecommendationOutputTab>(
+    improvedPrisma ? "prisma" : "prompt",
+  );
+  const content =
+    tab === "prisma"
+      ? (improvedPrisma ?? "")
+      : tab === "sql"
+        ? (improvedSql ?? "")
+        : buildRecommendationPrompt(recommendation, query);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <HighlightedText text={recommendation} />
+      <div className="overflow-hidden rounded-md border border-border bg-muted/20">
+        <div className="flex items-center justify-end border-b border-border bg-background px-2 py-1.5">
+          <Select
+            onValueChange={(value) => setTab(value as RecommendationOutputTab)}
+            value={tab}
+          >
+            <SelectTrigger className="h-8 w-32 font-sans" label="Copy">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="prompt">Prompt</SelectItem>
+                <SelectItem disabled={!improvedSql} value="sql">
+                  SQL
+                </SelectItem>
+                <SelectItem disabled={!improvedPrisma} value="prisma">
+                  Prisma
+                </SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+        <EmbeddedCodeBlock
+          language={tab === "prisma" ? "ts" : tab === "sql" ? "sql" : "text"}
+          onCopied={() =>
+            onCopied(
+              tab === "prisma" ? "prisma" : tab === "sql" ? "sql" : "ai-prompt",
+            )
+          }
+        >
+          {content}
+        </EmbeddedCodeBlock>
+      </div>
+    </div>
+  );
+}
+
+function AnalysisResult(props: {
+  onCopied: (tab: "ai-prompt" | "prisma" | "sql") => void;
+  query: QueryInsightsQuery;
+  result: QueryInsightsAnalysisResult;
+}) {
+  const { onCopied, query, result } = props;
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        {renderMarkdownText(result.analysisMarkdown).map((block, index) =>
+          block.type === "heading" ? (
+            <h3 className="text-xl font-semibold leading-7" key={index}>
+              {block.text}
+            </h3>
+          ) : (
+            <p className="m-0 text-base leading-7 text-foreground" key={index}>
+              {block.text}
+            </p>
+          ),
+        )}
+      </div>
+
+      {result.issuesFound.length > 0 ? (
+        <div className="flex flex-col gap-2">
+          <h3 className="text-lg font-semibold leading-7">Issues</h3>
+          <ul className="flex flex-col gap-1 text-base leading-7 text-foreground">
+            {result.issuesFound.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {result.recommendations.length > 0 ? (
+        <div className="flex flex-col gap-4">
+          <h3 className="text-xl font-semibold leading-7">Recommendations</h3>
+          <div className="flex flex-col gap-4">
+            {result.recommendations.map((recommendation) => (
+              <RecommendationBlock
+                improvedPrisma={result.improvedPrisma}
+                improvedSql={result.improvedSql}
+                key={recommendation}
+                onCopied={onCopied}
+                query={query}
+                recommendation={recommendation}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ConsentPanel(props: {
+  isEnabling: boolean;
+  onEnable: () => Promise<void>;
+}) {
+  const { isEnabling, onEnable } = props;
+
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-border p-8 text-center">
+      <div className="flex max-w-lg flex-col items-center gap-4">
+        <div className="flex flex-col gap-2">
+          <h3 className="m-0 text-xl font-semibold leading-7">
+            Enable AI-powered recommendations
+          </h3>
+          <p className="m-0 text-sm leading-6 text-muted-foreground">
+            Enabling this feature will pass query structure to generative AI to
+            identify improvements in your queries. Query parameters are not used
+            for this feature and are not visible, stored, or used for AI in any
+            way.
+          </p>
+        </div>
+        <Button
+          disabled={isEnabling}
+          onClick={() => {
+            void onEnable();
+          }}
+          type="button"
+        >
+          {isEnabling ? "Enabling..." : "Show Query Insights"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function QueryAnalysisState(props: {
+  analysis: QueryInsightsAnalysisResult | null;
+  error: string | null;
+  isAnalyzing: boolean;
+  onCopied: (tab: "ai-prompt" | "prisma" | "sql") => void;
+  query: QueryInsightsQuery | null | undefined;
+}) {
+  const { analysis, error, isAnalyzing, onCopied, query } = props;
+
+  if (isAnalyzing) {
+    return (
+      <div className="flex items-center justify-center gap-3 py-24 text-muted-foreground">
+        <Loader2 className="animate-spin" data-icon="inline-start" />
+        <span className="text-lg">Analyzing query...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/40 p-4 text-sm text-muted-foreground">
+        {error}
+      </div>
+    );
+  }
+
+  if (analysis && query) {
+    return (
+      <AnalysisResult onCopied={onCopied} query={query} result={analysis} />
+    );
+  }
+
+  return null;
+}
+
+function ChildSqlCard(props: {
+  index: number;
+  onCopied: () => void;
+  query: QueryInsightsQuery;
+}) {
+  const { index, onCopied, query } = props;
+  const tableText =
+    query.tables.length > 0 ? formatTableList(query.tables) : null;
+  const ordinal =
+    index === 0
+      ? "first"
+      : index === 1
+        ? "second"
+        : index === 2
+          ? "third"
+          : `#${index + 1}`;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="m-0 text-base leading-7 text-foreground">
+        The {ordinal} SQL query had an average latency of{" "}
+        <span className="font-medium">{formatLatency(query.duration)}</span>.
+        {tableText
+          ? ` It accessed ${tableText} ${
+              query.tables.length === 1 ? "table" : "tables"
+            }.`
+          : ""}{" "}
+        This query returned{" "}
+        <span className="font-medium">{formatNumber(query.rowsReturned)}</span>{" "}
+        rows.
+      </p>
+      <EmbeddedCodeBlock language="sql" onCopied={onCopied}>
+        {query.query}
+      </EmbeddedCodeBlock>
+    </div>
+  );
+}
+
+function DetailSheet(props: {
+  hasNext: boolean;
+  hasPrevious: boolean;
+  onClose: () => void;
+  onCopied: (tab: "ai-prompt" | "prisma" | "sql") => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  row: QueryInsightsDisplayRow | null;
+}) {
+  const { hasNext, hasPrevious, onClose, onCopied, onNext, onPrevious, row } =
+    props;
+  const { analysis, enable, error, isAiEnabled, isAnalyzing, isEnabling } =
+    useQueryInsightsAnalysis(row);
+  const { queryInsights } = useStudio();
+  const scopeRef = useRef<HTMLSpanElement | null>(null);
+  const isOpen = row !== null;
+  const scopePortalContainer = scopeRef.current?.closest(".ps");
+  const portalContainer =
+    scopePortalContainer instanceof HTMLElement
+      ? scopePortalContainer
+      : typeof document === "undefined"
+        ? null
+        : document.body;
+
+  useEffect(() => {
+    if (isOpen && !isAiEnabled) {
+      queryInsights?.onEvent?.({
+        name: "studio:query_insights:ai_consent_callout_viewed",
+      });
+    }
+  }, [isAiEnabled, isOpen, queryInsights]);
+
+  return (
+    <>
+      <span ref={scopeRef} aria-hidden="true" className="hidden" />
+      <Sheet
+        open={isOpen}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            onClose();
+          }
+        }}
+      >
+        <SheetContent
+          className="inset-y-2 right-2 flex h-[calc(100dvh-1rem)] w-[min(42rem,calc(100vw-1rem))] max-w-none flex-col overflow-hidden rounded-xl border border-border bg-background p-0 font-sans text-foreground shadow-xl sm:max-w-none"
+          container={portalContainer}
+          showCloseButton={false}
+        >
+          {row ? (
+            <>
+              <SheetHeader className="sr-only">
+                <SheetTitle>Query analysis</SheetTitle>
+                <SheetDescription>
+                  Query runtime summary and AI recommendations.
+                </SheetDescription>
+              </SheetHeader>
+
+              <div className="flex shrink-0 items-center justify-between px-6 pb-4 pt-8">
+                <div className="inline-flex items-stretch overflow-hidden rounded-md border border-border bg-background shadow-sm">
+                  <Button
+                    aria-label="Previous query"
+                    className="size-9 rounded-none border-0 border-r border-border shadow-none"
+                    disabled={!hasPrevious}
+                    onClick={onPrevious}
+                    size="icon"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <ChevronLeft data-icon="inline-start" />
+                  </Button>
+                  <Button
+                    aria-label="Next query"
+                    className="size-9 rounded-none border-0 shadow-none"
+                    disabled={!hasNext}
+                    onClick={onNext}
+                    size="icon"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <ChevronRight data-icon="inline-start" />
+                  </Button>
+                </div>
+                <div className="inline-flex items-stretch overflow-hidden rounded-md border border-border bg-background shadow-sm">
+                  <Button
+                    aria-label="Close panel"
+                    className="size-9 rounded-none border-0 shadow-none"
+                    onClick={onClose}
+                    size="icon"
+                    type="button"
+                    variant="ghost"
+                  >
+                    <X data-icon="inline-start" />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="min-h-0 flex-1 overflow-auto px-6 pb-6">
+                {!isAiEnabled ? (
+                  <div className="flex min-h-full flex-col">
+                    <ConsentPanel isEnabling={isEnabling} onEnable={enable} />
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-5">
+                    <ProseSummary row={row} />
+
+                    {row.type === "group" ? (
+                      <>
+                        <EmbeddedCodeBlock
+                          language="ts"
+                          onCopied={() => onCopied("prisma")}
+                        >
+                          {formatPrismaCall(row.group)}
+                        </EmbeddedCodeBlock>
+                        {row.group.children.map((child, index) => (
+                          <ChildSqlCard
+                            index={index}
+                            key={child.id}
+                            onCopied={() => onCopied("sql")}
+                            query={child}
+                          />
+                        ))}
+                      </>
+                    ) : (
+                      <CollapsibleSqlBlock
+                        onCopied={() => onCopied("sql")}
+                        query={row.query}
+                      />
+                    )}
+
+                    <QueryAnalysisState
+                      analysis={analysis}
+                      error={error}
+                      isAnalyzing={isAnalyzing}
+                      onCopied={onCopied}
+                      query={
+                        row.type === "group" ? row.group.children[0] : row.query
+                      }
+                    />
+                  </div>
+                )}
+              </div>
+            </>
+          ) : null}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function formatPrismaCall(group: QueryInsightsGroup): string {
+  const { prismaQueryInfo } = group;
+  const prefix = prismaQueryInfo.model
+    ? `prisma.${prismaQueryInfo.model[0]?.toLowerCase()}${prismaQueryInfo.model.slice(1)}.`
+    : "prisma.";
+
+  if (!prismaQueryInfo.payload) {
+    return `${prefix}${prismaQueryInfo.action}()`;
+  }
+
+  return `${prefix}${prismaQueryInfo.action}(${JSON.stringify(
+    prismaQueryInfo.payload,
+    null,
+    2,
+  )})`;
+}
+
+export function QueryInsightsView() {
+  const { queryInsights } = useStudio();
+  const {
+    queryInsightsSortParam,
+    queryInsightsTableParam,
+    setQueryInsightsSortParam,
+    setQueryInsightsTableParam,
+  } = useNavigation();
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [chartData, setChartData] = useState<QueryInsightsChartPoint[]>([]);
+  const [selectedRowKey, setSelectedRowKey] = useState<string | null>(null);
+  const wasAutoPausedRef = useRef(false);
+  const rows = useQueryInsightsRows();
+  const sort = parseSortParam(queryInsightsSortParam);
+  const selectedTable = queryInsightsTableParam || null;
+  const availableTables = useMemo(
+    () => getAvailableQueryInsightTables(rows.queries),
+    [rows.queries],
+  );
+  const filteredQueries = useMemo(
+    () => filterQueryInsightsByTable(rows.queries, selectedTable),
+    [rows.queries, selectedTable],
+  );
+  const displayRows = useMemo(
+    () => buildQueryInsightsDisplayRows(filteredQueries, sort),
+    [filteredQueries, sort],
+  );
+  const selectedRowIndex = displayRows.findIndex((row) =>
+    rowMatchesKey(row, selectedRowKey),
+  );
+  const selectedRow =
+    selectedRowIndex >= 0 ? (displayRows[selectedRowIndex] ?? null) : null;
+  const canShowRows = rows.queries.length > 0;
+
+  const addChartPoints = useCallback((points: QueryInsightsChartPoint[]) => {
+    if (points.length === 0) {
+      return;
+    }
+
+    setChartData((current) => {
+      const nextByTimestamp = new Map<number, QueryInsightsChartPoint>();
+
+      for (const point of current) {
+        nextByTimestamp.set(point.ts, point);
+      }
+
+      for (const point of points) {
+        const existing = nextByTimestamp.get(point.ts);
+        nextByTimestamp.set(
+          point.ts,
+          existing ? mergeChartPoints(existing, point) : point,
+        );
+      }
+
+      return Array.from(nextByTimestamp.values())
+        .sort((left, right) => left.ts - right.ts)
+        .slice(-QUERY_INSIGHTS_CHART_BUFFER_LIMIT);
+    });
+  }, []);
+  const handleStreamError = useCallback(
+    (message: string) => {
+      setStreamError(message);
+      queryInsights?.onEvent?.({
+        name: "studio:query_insights:stream_error",
+        payload: { message },
+      });
+    },
+    [queryInsights],
+  );
+  const { status } = useQueryInsightsStream({
+    onChartTicks: addChartPoints,
+    onError: handleStreamError,
+    onQueries: rows.ingestQueries,
+    streamUrl: queryInsights?.streamUrl ?? "",
+  });
+
+  useEffect(() => {
+    queryInsights?.onEvent?.({ name: "studio:query_insights:viewed" });
+  }, [queryInsights]);
+
+  useEffect(() => {
+    if (canShowRows) {
+      queryInsights?.onEvent?.({
+        name: "studio:query_insights:query_displayed",
+      });
+    }
+  }, [canShowRows, queryInsights]);
+
+  if (!queryInsights) {
+    return null;
+  }
+
+  function handleSelectRow(row: QueryInsightsDisplayRow) {
+    setSelectedRowKey(getRowKey(row));
+
+    if (!rows.isPaused) {
+      wasAutoPausedRef.current = true;
+      rows.pause();
+    }
+
+    queryInsights?.onEvent?.({
+      name: "studio:query_insights:query_detail_opened",
+      payload: {
+        rowKey: getRowKey(row),
+        type: row.type,
+      },
+    });
+  }
+
+  function closeDetail() {
+    setSelectedRowKey(null);
+
+    if (wasAutoPausedRef.current) {
+      wasAutoPausedRef.current = false;
+      rows.resume();
+    }
+  }
+
+  function togglePause() {
+    wasAutoPausedRef.current = false;
+
+    if (rows.isPaused) {
+      rows.resume();
+      queryInsights?.onEvent?.({
+        name: "studio:query_insights:table_resumed",
+        payload: { bufferSize: rows.pauseBufferSize },
+      });
+      return;
+    }
+
+    rows.pause();
+    queryInsights?.onEvent?.({
+      name: "studio:query_insights:table_paused",
+      payload: { queryCount: rows.queries.length },
+    });
+  }
+
+  function navigateDetail(direction: -1 | 1) {
+    const nextRow = displayRows[selectedRowIndex + direction];
+
+    if (nextRow) {
+      setSelectedRowKey(getRowKey(nextRow));
+    }
+  }
+
+  function renderFilterControls() {
+    return (
+      <>
+        <Select
+          onValueChange={(value) => {
+            const nextValue = value === ALL_TABLES_VALUE ? null : value;
+            void setQueryInsightsTableParam(nextValue);
+            queryInsights?.onEvent?.({
+              name: "studio:query_insights:filter_applied",
+              payload: { table: nextValue },
+            });
+          }}
+          value={selectedTable ?? ALL_TABLES_VALUE}
+        >
+          <SelectTrigger className="w-full font-sans sm:w-44" label="Table">
+            <SelectValue placeholder="All tables" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value={ALL_TABLES_VALUE}>All tables</SelectItem>
+              {availableTables.map((table) => (
+                <SelectItem key={table} value={table}>
+                  {table}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+
+        <Select
+          onValueChange={(value) => {
+            const nextSort = parseSortParam(value);
+            const serialized = serializeSort(nextSort);
+
+            void setQueryInsightsSortParam(
+              serialized === serializeSort(QUERY_INSIGHTS_DEFAULT_SORT)
+                ? null
+                : serialized,
+            );
+            queryInsights?.onEvent?.({
+              name: "studio:query_insights:sort_changed",
+              payload: { ...nextSort },
+            });
+          }}
+          value={serializeSort(sort)}
+        >
+          <SelectTrigger className="w-full font-sans sm:w-52" label="Sort">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {SORT_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <StudioHeader
+        endContent={
+          <div className="hidden items-center gap-2 lg:flex">
+            {renderFilterControls()}
+          </div>
+        }
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="hidden min-w-0 flex-col sm:flex">
+            <span className="truncate text-sm font-medium text-foreground">
+              Query Insights
+            </span>
+            <span className="truncate text-xs text-muted-foreground">
+              Live query metrics
+            </span>
+          </div>
+          <Button
+            className="h-9 shrink-0 font-sans"
+            onClick={togglePause}
+            size="sm"
+            type="button"
+            variant={rows.isPaused ? "default" : "outline"}
+          >
+            {rows.isPaused ? (
+              <Play data-icon="inline-start" />
+            ) : (
+              <Pause data-icon="inline-start" />
+            )}
+            {rows.isPaused ? "Resume" : "Pause"}
+          </Button>
+        </div>
+      </StudioHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 p-3">
+        <div className="grid shrink-0 grid-cols-1 gap-2 sm:grid-cols-2 lg:hidden">
+          {renderFilterControls()}
+        </div>
+
+        <div className="grid shrink-0 grid-cols-1 gap-3 lg:grid-cols-2">
+          <QueryInsightsChart
+            data={chartData}
+            kind="latency"
+            loading={status === "connecting" && chartData.length === 0}
+            title="Average Latency"
+          />
+          <QueryInsightsChart
+            data={chartData}
+            kind="qps"
+            loading={status === "connecting" && chartData.length === 0}
+            title="Queries Per Second"
+          />
+        </div>
+
+        {streamError ? (
+          <div className="rounded-md border border-destructive/40 px-3 py-2 text-sm text-muted-foreground">
+            {streamError}
+          </div>
+        ) : null}
+
+        {displayRows.length > 0 ? (
+          <QueryInsightsTable
+            displayRows={displayRows}
+            flushedIds={rows.flushedIds}
+            isAtLimit={rows.isAtLimit}
+            isPaused={rows.isPaused}
+            onSelectRow={handleSelectRow}
+            pauseBufferSize={rows.pauseBufferSize}
+            recentlyAddedIds={rows.recentlyAddedIds}
+            selectedRowKey={selectedRowKey}
+            sort={sort}
+          />
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-border bg-background p-8 text-center">
+            <div className="flex max-w-md flex-col items-center gap-3">
+              {selectedTable ? (
+                <SearchX className="text-muted-foreground" />
+              ) : (
+                <DatabaseZap className="text-muted-foreground" />
+              )}
+              <div className="text-sm font-medium">
+                {selectedTable ? "No matching queries" : "Waiting for activity"}
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                {selectedTable
+                  ? "Queries for the selected table will appear here when they are observed."
+                  : "Run SQL in Studio or append query events to prisma-log to populate Query Insights."}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <DetailSheet
+        hasNext={
+          selectedRowIndex !== -1 && selectedRowIndex < displayRows.length - 1
+        }
+        hasPrevious={selectedRowIndex > 0}
+        onClose={closeDetail}
+        onCopied={(tab) => {
+          queryInsights.onEvent?.({
+            name: "studio:query_insights:output_copied",
+            payload: { tab },
+          });
+        }}
+        onNext={() => navigateDetail(1)}
+        onPrevious={() => navigateDetail(-1)}
+        row={selectedRow}
+      />
+    </div>
+  );
+}

--- a/ui/studio/views/query-insights/codecs.test.ts
+++ b/ui/studio/views/query-insights/codecs.test.ts
@@ -29,6 +29,7 @@ describe("Query Insights stream codecs", () => {
           sql: "select id from users",
           tables: ["users"],
           ts: 1_700_000_000_000,
+          visibility: "user",
         },
       ]),
     );
@@ -48,6 +49,7 @@ describe("Query Insights stream codecs", () => {
         model: "User",
       },
       queryId: "query-1",
+      visibility: "user",
     });
     expect(chartTick).toEqual({
       data: {
@@ -85,6 +87,7 @@ describe("Query Insights stream codecs", () => {
           tables: ["organizations"],
           ts: 1_700_000_000_100,
           type: "query",
+          visibility: "studio-system",
         },
         {
           count: 2,
@@ -124,6 +127,7 @@ describe("Query Insights stream codecs", () => {
 
     expect(decoded.success).toBe(true);
     expect(decoded.data).toHaveLength(3);
+    expect(decoded.data?.[0]?.visibility).toBe("studio-system");
     expect(createChartTicksFromQueries(decoded.data ?? [])).toEqual([
       {
         avgDurationMs: 40 / 3,

--- a/ui/studio/views/query-insights/codecs.test.ts
+++ b/ui/studio/views/query-insights/codecs.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createChartTicksFromQueries,
+  safeDecodeChartTickEvent,
+  safeDecodePrismaLogDataEvent,
+  safeDecodeQueriesEvent,
+} from "./codecs";
+
+describe("Query Insights stream codecs", () => {
+  it("decodes query and chart events with Prisma metadata", () => {
+    const queries = safeDecodeQueriesEvent(
+      JSON.stringify([
+        {
+          count: 2,
+          durationMs: 12.5,
+          groupKey: "User.findMany:{}",
+          maxDurationMs: 20,
+          minDurationMs: 10,
+          prismaQueryInfo: {
+            action: "findMany",
+            isRaw: false,
+            model: "User",
+            payload: { select: { id: true } },
+          },
+          queryId: "query-1",
+          reads: 8,
+          rowsReturned: 2,
+          sql: "select id from users",
+          tables: ["users"],
+          ts: 1_700_000_000_000,
+        },
+      ]),
+    );
+    const chartTick = safeDecodeChartTickEvent(
+      JSON.stringify({
+        avgDurationMs: 12.5,
+        queryCount: 2,
+        ts: 1_700_000_000_000,
+      }),
+    );
+
+    expect(queries.success).toBe(true);
+    expect(queries.data?.[0]).toMatchObject({
+      count: 2,
+      prismaQueryInfo: {
+        action: "findMany",
+        model: "User",
+      },
+      queryId: "query-1",
+    });
+    expect(chartTick).toEqual({
+      data: {
+        avgDurationMs: 12.5,
+        queryCount: 2,
+        ts: 1_700_000_000_000,
+      },
+      success: true,
+    });
+  });
+
+  it("rejects malformed events without throwing", () => {
+    const decoded = safeDecodeQueriesEvent(
+      JSON.stringify([{ count: 0, sql: "select 1" }]),
+    );
+
+    expect(decoded.success).toBe(false);
+    expect(decoded.error?.message).toContain("durationMs");
+  });
+
+  it("decodes prisma-log stream data events and derives bucketed chart ticks", () => {
+    const decoded = safeDecodePrismaLogDataEvent(
+      JSON.stringify([
+        {
+          count: 1,
+          durationMs: 20,
+          groupKey: null,
+          maxDurationMs: 20,
+          minDurationMs: 20,
+          prismaQueryInfo: null,
+          queryId: null,
+          reads: 0,
+          rowsReturned: 3,
+          sql: "select * from organizations",
+          tables: ["organizations"],
+          ts: 1_700_000_000_100,
+          type: "query",
+        },
+        {
+          count: 2,
+          durationMs: 10,
+          groupKey: null,
+          maxDurationMs: 10,
+          minDurationMs: 10,
+          prismaQueryInfo: null,
+          queryId: null,
+          reads: 0,
+          rowsReturned: 6,
+          sql: "select * from organizations",
+          tables: ["organizations"],
+          ts: 1_700_000_000_700,
+          type: "query",
+        },
+        {
+          count: 1,
+          durationMs: 30,
+          groupKey: null,
+          maxDurationMs: 30,
+          minDurationMs: 30,
+          prismaQueryInfo: null,
+          queryId: null,
+          reads: 0,
+          rowsReturned: 1,
+          sql: "select * from all_data_types",
+          tables: ["all_data_types"],
+          ts: 1_700_000_001_300,
+          type: "query",
+        },
+        {
+          type: "heartbeat",
+        },
+      ]),
+    );
+
+    expect(decoded.success).toBe(true);
+    expect(decoded.data).toHaveLength(3);
+    expect(createChartTicksFromQueries(decoded.data ?? [])).toEqual([
+      {
+        avgDurationMs: 40 / 3,
+        queryCount: 3,
+        ts: 1_700_000_000_000,
+      },
+      {
+        avgDurationMs: 30,
+        queryCount: 1,
+        ts: 1_700_000_001_000,
+      },
+    ]);
+  });
+});

--- a/ui/studio/views/query-insights/codecs.ts
+++ b/ui/studio/views/query-insights/codecs.ts
@@ -1,0 +1,290 @@
+import {
+  QUERY_INSIGHTS_CHART_BUCKET_MS,
+  type QueryInsightsChartPoint,
+  type QueryInsightsPrismaInfo,
+  type QueryInsightsStreamQuery,
+} from "./types";
+
+export interface SafeDecodeResult<T> {
+  data?: T;
+  error?: Error;
+  success: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Invalid Query Insights event: ${field} must be a number.`);
+  }
+
+  return value;
+}
+
+function assertString(value: unknown, field: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`Invalid Query Insights event: ${field} must be a string.`);
+  }
+
+  return value;
+}
+
+function assertStringArray(value: unknown, field: string): string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    throw new Error(
+      `Invalid Query Insights event: ${field} must be a string array.`,
+    );
+  }
+
+  return value.map((item) => String(item));
+}
+
+function decodePrismaInfo(value: unknown): QueryInsightsPrismaInfo | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (!isRecord(value)) {
+    throw new Error(
+      "Invalid Query Insights event: prismaQueryInfo must be an object or null.",
+    );
+  }
+
+  const action = assertString(value.action, "prismaQueryInfo.action");
+
+  if (typeof value.isRaw !== "boolean") {
+    throw new Error(
+      "Invalid Query Insights event: prismaQueryInfo.isRaw must be a boolean.",
+    );
+  }
+
+  const model =
+    typeof value.model === "string" && value.model.length > 0
+      ? value.model
+      : undefined;
+  const payload =
+    isRecord(value.payload) || Array.isArray(value.payload)
+      ? (value.payload as QueryInsightsPrismaInfo["payload"])
+      : undefined;
+
+  return {
+    action,
+    isRaw: value.isRaw,
+    model,
+    payload,
+  };
+}
+
+function decodeOptionalNumber(value: unknown): number | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  return assertNumber(value, "optional numeric field");
+}
+
+function decodeOptionalString(value: unknown): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  return assertString(value, "optional string field");
+}
+
+function decodeStreamQuery(value: unknown): QueryInsightsStreamQuery {
+  if (!isRecord(value)) {
+    throw new Error(
+      "Invalid Query Insights event: query row must be an object.",
+    );
+  }
+
+  const count = assertNumber(value.count, "count");
+  const durationMs = assertNumber(value.durationMs, "durationMs");
+  const sql = assertString(value.sql, "sql");
+  const ts = assertNumber(value.ts, "ts");
+
+  if (!Number.isInteger(count) || count <= 0) {
+    throw new Error(
+      "Invalid Query Insights event: count must be a positive integer.",
+    );
+  }
+
+  if (!Number.isInteger(ts) || ts <= 0) {
+    throw new Error(
+      "Invalid Query Insights event: ts must be a positive integer.",
+    );
+  }
+
+  return {
+    count,
+    durationMs,
+    groupKey: decodeOptionalString(value.groupKey),
+    maxDurationMs: decodeOptionalNumber(value.maxDurationMs),
+    minDurationMs: decodeOptionalNumber(value.minDurationMs),
+    prismaQueryInfo: decodePrismaInfo(value.prismaQueryInfo),
+    queryId: decodeOptionalString(value.queryId),
+    reads: assertNumber(value.reads, "reads"),
+    rowsReturned: assertNumber(value.rowsReturned, "rowsReturned"),
+    sql,
+    tables: assertStringArray(value.tables, "tables"),
+    ts,
+  };
+}
+
+export function decodeQueriesEvent(
+  jsonString: string,
+): QueryInsightsStreamQuery[] {
+  const parsed = JSON.parse(jsonString) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new Error("Invalid Query Insights event: queries must be an array.");
+  }
+
+  return parsed.map(decodeStreamQuery);
+}
+
+export function decodePrismaLogDataEvent(
+  jsonString: string,
+): QueryInsightsStreamQuery[] {
+  const parsed = JSON.parse(jsonString) as unknown;
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "Invalid Query Insights stream event: prisma-log data must be an array.",
+    );
+  }
+
+  return parsed
+    .filter((value) => isRecord(value) && value.type === "query")
+    .map(decodeStreamQuery);
+}
+
+export function decodeChartTickEvent(
+  jsonString: string,
+): QueryInsightsChartPoint {
+  const parsed = JSON.parse(jsonString) as unknown;
+
+  if (!isRecord(parsed)) {
+    throw new Error(
+      "Invalid Query Insights event: chartTick must be an object.",
+    );
+  }
+
+  const ts = assertNumber(parsed.ts, "ts");
+  const queryCount = assertNumber(parsed.queryCount, "queryCount");
+  const avgDurationMs = assertNumber(parsed.avgDurationMs, "avgDurationMs");
+
+  if (!Number.isInteger(ts) || ts <= 0) {
+    throw new Error(
+      "Invalid Query Insights event: ts must be a positive integer.",
+    );
+  }
+
+  if (!Number.isInteger(queryCount) || queryCount < 0) {
+    throw new Error(
+      "Invalid Query Insights event: queryCount must be a non-negative integer.",
+    );
+  }
+
+  return {
+    avgDurationMs,
+    queryCount,
+    ts,
+  };
+}
+
+export function safeDecodeQueriesEvent(
+  jsonString: string,
+): SafeDecodeResult<QueryInsightsStreamQuery[]> {
+  try {
+    return {
+      data: decodeQueriesEvent(jsonString),
+      success: true,
+    };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      success: false,
+    };
+  }
+}
+
+export function safeDecodePrismaLogDataEvent(
+  jsonString: string,
+): SafeDecodeResult<QueryInsightsStreamQuery[]> {
+  try {
+    return {
+      data: decodePrismaLogDataEvent(jsonString),
+      success: true,
+    };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      success: false,
+    };
+  }
+}
+
+export function safeDecodeChartTickEvent(
+  jsonString: string,
+): SafeDecodeResult<QueryInsightsChartPoint> {
+  try {
+    return {
+      data: decodeChartTickEvent(jsonString),
+      success: true,
+    };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error : new Error(String(error)),
+      success: false,
+    };
+  }
+}
+
+export function createChartTicksFromQueries(
+  queries: QueryInsightsStreamQuery[],
+  bucketMs = QUERY_INSIGHTS_CHART_BUCKET_MS,
+): QueryInsightsChartPoint[] {
+  if (queries.length === 0) {
+    return [];
+  }
+
+  const buckets = new Map<
+    number,
+    {
+      queryCount: number;
+      totalDurationMs: number;
+    }
+  >();
+
+  for (const query of queries) {
+    const ts = Math.floor(query.ts / bucketMs) * bucketMs;
+    const bucket = buckets.get(ts) ?? {
+      queryCount: 0,
+      totalDurationMs: 0,
+    };
+
+    bucket.queryCount += query.count;
+    bucket.totalDurationMs += query.durationMs * query.count;
+    buckets.set(ts, bucket);
+  }
+
+  return Array.from(buckets.entries())
+    .sort(([left], [right]) => left - right)
+    .map(([ts, bucket]) => ({
+      avgDurationMs:
+        bucket.queryCount > 0 ? bucket.totalDurationMs / bucket.queryCount : 0,
+      queryCount: bucket.queryCount,
+      ts,
+    }));
+}

--- a/ui/studio/views/query-insights/codecs.ts
+++ b/ui/studio/views/query-insights/codecs.ts
@@ -2,6 +2,7 @@ import {
   QUERY_INSIGHTS_CHART_BUCKET_MS,
   type QueryInsightsChartPoint,
   type QueryInsightsPrismaInfo,
+  type QueryInsightsQueryVisibility,
   type QueryInsightsStreamQuery,
 } from "./types";
 
@@ -101,6 +102,22 @@ function decodeOptionalString(value: unknown): string | null | undefined {
   return assertString(value, "optional string field");
 }
 
+function decodeOptionalVisibility(
+  value: unknown,
+): QueryInsightsQueryVisibility | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === "studio-system" || value === "user") {
+    return value;
+  }
+
+  throw new Error(
+    "Invalid Query Insights event: visibility must be studio-system or user.",
+  );
+}
+
 function decodeStreamQuery(value: unknown): QueryInsightsStreamQuery {
   if (!isRecord(value)) {
     throw new Error(
@@ -138,6 +155,7 @@ function decodeStreamQuery(value: unknown): QueryInsightsStreamQuery {
     sql,
     tables: assertStringArray(value.tables, "tables"),
     ts,
+    visibility: decodeOptionalVisibility(value.visibility),
   };
 }
 

--- a/ui/studio/views/query-insights/rows.test.ts
+++ b/ui/studio/views/query-insights/rows.test.ts
@@ -64,6 +64,7 @@ describe("Query Insights row helpers", () => {
       duration: 84.2,
       reads: 12,
       rowsReturned: 2,
+      visibility: undefined,
     });
   });
 

--- a/ui/studio/views/query-insights/rows.test.ts
+++ b/ui/studio/views/query-insights/rows.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildQueryInsightsDisplayRows,
+  filterQueryInsightsByTable,
+  getAvailableQueryInsightTables,
+  upsertQueryInsights,
+  upsertQueryInsightsPauseBuffer,
+} from "./rows";
+import type { QueryInsightsQuery, QueryInsightsStreamQuery } from "./types";
+
+function streamQuery(
+  overrides: Partial<QueryInsightsStreamQuery> & { sql: string },
+): QueryInsightsStreamQuery {
+  return {
+    count: 1,
+    durationMs: 25,
+    groupKey: null,
+    maxDurationMs: null,
+    minDurationMs: null,
+    prismaQueryInfo: null,
+    queryId: null,
+    reads: 0,
+    rowsReturned: 1,
+    tables: ["users"],
+    ts: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe("Query Insights row helpers", () => {
+  it("upserts rows by query identity and caps by last-seen recency", () => {
+    const { next } = upsertQueryInsights(
+      new Map(),
+      [
+        streamQuery({ sql: "select * from users", ts: 1 }),
+        streamQuery({ sql: "select * from posts", ts: 2 }),
+        streamQuery({ sql: "select * from comments", ts: 3 }),
+      ],
+      2,
+    );
+
+    expect(Array.from(next.keys())).toEqual([
+      "select * from comments",
+      "select * from posts",
+    ]);
+
+    const updated = upsertQueryInsights(
+      next,
+      [
+        streamQuery({
+          count: 4,
+          durationMs: 99,
+          reads: 12,
+          sql: "select * from posts",
+          ts: 4,
+        }),
+      ],
+      2,
+    ).next;
+
+    expect(updated.get("select * from posts")).toMatchObject({
+      count: 5,
+      duration: 84.2,
+      reads: 12,
+      rowsReturned: 2,
+    });
+  });
+
+  it("groups Prisma operations by group key and sorts aggregate rows", () => {
+    const queries: QueryInsightsQuery[] = [
+      {
+        count: 2,
+        duration: 50,
+        groupKey: "User.findMany:{}",
+        id: "a",
+        lastSeen: 20,
+        prismaQueryInfo: {
+          action: "findMany",
+          isRaw: false,
+          model: "User",
+        },
+        query: "select * from users",
+        reads: 10,
+        rowsReturned: 2,
+        tables: ["users"],
+      },
+      {
+        count: 1,
+        duration: 300,
+        groupKey: "User.findMany:{}",
+        id: "b",
+        lastSeen: 30,
+        prismaQueryInfo: {
+          action: "findMany",
+          isRaw: false,
+          model: "User",
+        },
+        query: "select * from posts",
+        reads: 90,
+        rowsReturned: 5,
+        tables: ["posts"],
+      },
+      {
+        count: 9,
+        duration: 10,
+        id: "c",
+        lastSeen: 10,
+        query: "select * from audits",
+        reads: 1,
+        rowsReturned: 9,
+        tables: ["audits"],
+      },
+    ];
+
+    const rows = buildQueryInsightsDisplayRows(queries, {
+      direction: "desc",
+      field: "reads",
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.type).toBe("group");
+    expect(rows[0]?.type === "group" ? rows[0].group.totalReads : 0).toBe(100);
+    expect(rows[0]?.type === "group" ? rows[0].group.totalCount : 0).toBe(3);
+    expect(rows[0]?.type === "group" ? rows[0].group.tables : []).toEqual([
+      "posts",
+      "users",
+    ]);
+    expect(rows[1]?.type).toBe("standalone");
+  });
+
+  it("filters table names and caps paused buffers", () => {
+    const queries: QueryInsightsQuery[] = [
+      {
+        count: 1,
+        duration: 10,
+        id: "users",
+        lastSeen: 1,
+        query: "select * from users",
+        reads: 0,
+        rowsReturned: 1,
+        tables: ["users"],
+      },
+      {
+        count: 1,
+        duration: 10,
+        id: "posts",
+        lastSeen: 2,
+        query: "select * from posts",
+        reads: 0,
+        rowsReturned: 1,
+        tables: ["posts"],
+      },
+    ];
+
+    expect(getAvailableQueryInsightTables(queries)).toEqual(["posts", "users"]);
+    expect(
+      filterQueryInsightsByTable(queries, "posts").map((q) => q.id),
+    ).toEqual(["posts"]);
+
+    const buffer = upsertQueryInsightsPauseBuffer(
+      new Map(),
+      [
+        streamQuery({ sql: "a", ts: 1 }),
+        streamQuery({ sql: "b", ts: 2 }),
+        streamQuery({ sql: "c", ts: 3 }),
+      ],
+      2,
+    );
+
+    expect(Array.from(buffer.keys())).toEqual(["c", "b"]);
+  });
+});

--- a/ui/studio/views/query-insights/rows.ts
+++ b/ui/studio/views/query-insights/rows.ts
@@ -1,0 +1,303 @@
+import {
+  QUERY_INSIGHTS_MAX_QUERIES,
+  QUERY_INSIGHTS_PAUSE_BUFFER_LIMIT,
+  type QueryInsightsDisplayRow,
+  type QueryInsightsGroup,
+  type QueryInsightsQuery,
+  type QueryInsightsSortField,
+  type QueryInsightsSortState,
+  type QueryInsightsStreamQuery,
+} from "./types";
+
+export function getQueryInsightKey(
+  query: Pick<QueryInsightsStreamQuery, "groupKey" | "queryId" | "sql">,
+): string {
+  return query.queryId && query.groupKey
+    ? `${query.queryId}:${query.groupKey}`
+    : query.sql;
+}
+
+export function toQueryInsight(
+  query: QueryInsightsStreamQuery,
+): QueryInsightsQuery {
+  return {
+    count: query.count,
+    duration: query.durationMs,
+    groupKey: query.groupKey,
+    id: getQueryInsightKey(query),
+    lastSeen: query.ts,
+    maxDurationMs: query.maxDurationMs,
+    minDurationMs: query.minDurationMs,
+    prismaQueryInfo: query.prismaQueryInfo,
+    query: query.sql,
+    queryId: query.queryId,
+    reads: query.reads,
+    rowsReturned: query.rowsReturned,
+    tables: query.tables,
+  };
+}
+
+function mergeQueryInsight(
+  existing: QueryInsightsQuery | undefined,
+  incoming: QueryInsightsQuery,
+): QueryInsightsQuery {
+  if (!existing) {
+    return incoming;
+  }
+
+  const count = existing.count + incoming.count;
+  const duration =
+    count > 0
+      ? (existing.duration * existing.count +
+          incoming.duration * incoming.count) /
+        count
+      : incoming.duration;
+  const tables = new Set([...existing.tables, ...incoming.tables]);
+
+  return {
+    ...existing,
+    count,
+    duration,
+    groupKey: incoming.groupKey,
+    lastSeen: Math.max(existing.lastSeen, incoming.lastSeen),
+    maxDurationMs: Math.max(
+      existing.maxDurationMs ?? existing.duration,
+      incoming.maxDurationMs ?? incoming.duration,
+    ),
+    minDurationMs: Math.min(
+      existing.minDurationMs ?? existing.duration,
+      incoming.minDurationMs ?? incoming.duration,
+    ),
+    prismaQueryInfo: incoming.prismaQueryInfo,
+    queryId: incoming.queryId,
+    reads: existing.reads + incoming.reads,
+    rowsReturned: existing.rowsReturned + incoming.rowsReturned,
+    tables: Array.from(tables).sort(),
+  };
+}
+
+export function upsertQueryInsights(
+  current: Map<string, QueryInsightsQuery>,
+  incomingRows: QueryInsightsStreamQuery[],
+  limit = QUERY_INSIGHTS_MAX_QUERIES,
+): {
+  next: Map<string, QueryInsightsQuery>;
+  newIds: string[];
+} {
+  const next = new Map(current);
+  const newIds: string[] = [];
+
+  for (const incomingRow of incomingRows) {
+    const incoming = toQueryInsight(incomingRow);
+    const existing = next.get(incoming.id);
+
+    if (!existing) {
+      newIds.push(incoming.id);
+    }
+
+    next.set(incoming.id, mergeQueryInsight(existing, incoming));
+  }
+
+  if (next.size <= limit) {
+    return { next, newIds };
+  }
+
+  return {
+    next: new Map(
+      Array.from(next.entries())
+        .sort((left, right) => right[1].lastSeen - left[1].lastSeen)
+        .slice(0, limit),
+    ),
+    newIds,
+  };
+}
+
+export function upsertQueryInsightsPauseBuffer(
+  current: Map<string, QueryInsightsQuery>,
+  incomingRows: QueryInsightsStreamQuery[],
+  limit = QUERY_INSIGHTS_PAUSE_BUFFER_LIMIT,
+): Map<string, QueryInsightsQuery> {
+  const next = new Map(current);
+
+  for (const incomingRow of incomingRows) {
+    const incoming = toQueryInsight(incomingRow);
+    next.set(incoming.id, mergeQueryInsight(next.get(incoming.id), incoming));
+  }
+
+  if (next.size <= limit) {
+    return next;
+  }
+
+  return new Map(
+    Array.from(next.entries())
+      .sort((left, right) => right[1].lastSeen - left[1].lastSeen)
+      .slice(0, limit),
+  );
+}
+
+function getQuerySortValue(
+  query: QueryInsightsQuery,
+  field: QueryInsightsSortField,
+): number {
+  switch (field) {
+    case "executions":
+      return query.count;
+    case "lastSeen":
+      return query.lastSeen;
+    case "latency":
+      return query.duration;
+    case "reads":
+      return query.reads;
+  }
+}
+
+function getGroupSortValue(
+  group: QueryInsightsGroup,
+  field: QueryInsightsSortField,
+): number {
+  switch (field) {
+    case "executions":
+      return group.totalCount;
+    case "lastSeen":
+      return group.lastSeen;
+    case "latency":
+      return group.avgDuration;
+    case "reads":
+      return group.totalReads;
+  }
+}
+
+export function buildQueryInsightsDisplayRows(
+  queries: QueryInsightsQuery[],
+  sort: QueryInsightsSortState,
+): QueryInsightsDisplayRow[] {
+  const groups = new Map<string, QueryInsightsQuery[]>();
+  const standalone: QueryInsightsQuery[] = [];
+
+  for (const query of queries) {
+    if (query.groupKey) {
+      groups.set(query.groupKey, [
+        ...(groups.get(query.groupKey) ?? []),
+        query,
+      ]);
+      continue;
+    }
+
+    standalone.push(query);
+  }
+
+  const multiplier = sort.direction === "desc" ? -1 : 1;
+  const entries: Array<
+    | { group: QueryInsightsGroup; kind: "group" }
+    | { kind: "standalone"; query: QueryInsightsQuery }
+  > = [];
+
+  for (const [groupKey, children] of groups) {
+    const sortedChildren = [...children].sort(
+      (left, right) =>
+        multiplier *
+        (getQuerySortValue(left, sort.field) -
+          getQuerySortValue(right, sort.field)),
+    );
+    const firstChild = sortedChildren[0];
+
+    if (!firstChild?.prismaQueryInfo) {
+      standalone.push(...sortedChildren);
+      continue;
+    }
+
+    const tableSet = new Set<string>();
+    let totalCount = 0;
+    let totalDuration = 0;
+    let totalReads = 0;
+    let totalRows = 0;
+    let lastSeen = 0;
+    let minDuration = Number.POSITIVE_INFINITY;
+    let maxDuration = 0;
+
+    for (const child of sortedChildren) {
+      totalCount += child.count;
+      totalDuration += child.duration * child.count;
+      totalReads += child.reads;
+      totalRows += child.rowsReturned;
+      lastSeen = Math.max(lastSeen, child.lastSeen);
+      minDuration = Math.min(
+        minDuration,
+        child.minDurationMs ?? child.duration,
+      );
+      maxDuration = Math.max(
+        maxDuration,
+        child.maxDurationMs ?? child.duration,
+      );
+
+      for (const table of child.tables) {
+        tableSet.add(table);
+      }
+    }
+
+    entries.push({
+      group: {
+        avgDuration: totalCount > 0 ? totalDuration / totalCount : 0,
+        children: sortedChildren,
+        groupKey,
+        lastSeen,
+        maxDuration,
+        minDuration: minDuration === Number.POSITIVE_INFINITY ? 0 : minDuration,
+        prismaQueryInfo: firstChild.prismaQueryInfo,
+        tables: Array.from(tableSet).sort(),
+        totalCount,
+        totalReads,
+        totalRows,
+      },
+      kind: "group",
+    });
+  }
+
+  for (const query of standalone) {
+    entries.push({ kind: "standalone", query });
+  }
+
+  entries.sort((left, right) => {
+    const leftValue =
+      left.kind === "group"
+        ? getGroupSortValue(left.group, sort.field)
+        : getQuerySortValue(left.query, sort.field);
+    const rightValue =
+      right.kind === "group"
+        ? getGroupSortValue(right.group, sort.field)
+        : getQuerySortValue(right.query, sort.field);
+
+    return multiplier * (leftValue - rightValue);
+  });
+
+  return entries.map((entry) =>
+    entry.kind === "group"
+      ? { group: entry.group, type: "group" }
+      : { query: entry.query, type: "standalone" },
+  );
+}
+
+export function filterQueryInsightsByTable(
+  queries: QueryInsightsQuery[],
+  table: string | null,
+): QueryInsightsQuery[] {
+  if (!table) {
+    return queries;
+  }
+
+  return queries.filter((query) => query.tables.includes(table));
+}
+
+export function getAvailableQueryInsightTables(
+  queries: QueryInsightsQuery[],
+): string[] {
+  const tables = new Set<string>();
+
+  for (const query of queries) {
+    for (const table of query.tables) {
+      tables.add(table);
+    }
+  }
+
+  return Array.from(tables).sort();
+}

--- a/ui/studio/views/query-insights/rows.ts
+++ b/ui/studio/views/query-insights/rows.ts
@@ -34,6 +34,7 @@ export function toQueryInsight(
     reads: query.reads,
     rowsReturned: query.rowsReturned,
     tables: query.tables,
+    visibility: query.visibility,
   };
 }
 
@@ -73,6 +74,7 @@ function mergeQueryInsight(
     reads: existing.reads + incoming.reads,
     rowsReturned: existing.rowsReturned + incoming.rowsReturned,
     tables: Array.from(tables).sort(),
+    visibility: incoming.visibility ?? existing.visibility,
   };
 }
 

--- a/ui/studio/views/query-insights/types.ts
+++ b/ui/studio/views/query-insights/types.ts
@@ -10,6 +10,8 @@ export interface QueryInsightsPrismaInfo {
   payload?: Record<string, unknown> | Array<Record<string, unknown>>;
 }
 
+export type QueryInsightsQueryVisibility = "studio-system" | "user";
+
 export interface QueryInsightsQuery {
   count: number;
   duration: number;
@@ -24,6 +26,7 @@ export interface QueryInsightsQuery {
   reads: number;
   rowsReturned: number;
   tables: string[];
+  visibility?: QueryInsightsQueryVisibility;
 }
 
 export interface QueryInsightsStreamQuery {
@@ -39,6 +42,7 @@ export interface QueryInsightsStreamQuery {
   sql: string;
   tables: string[];
   ts: number;
+  visibility?: QueryInsightsQueryVisibility;
 }
 
 export interface QueryInsightsChartPoint {

--- a/ui/studio/views/query-insights/types.ts
+++ b/ui/studio/views/query-insights/types.ts
@@ -1,0 +1,133 @@
+export const QUERY_INSIGHTS_MAX_QUERIES = 500;
+export const QUERY_INSIGHTS_PAUSE_BUFFER_LIMIT = 500;
+export const QUERY_INSIGHTS_CHART_BUFFER_LIMIT = 100;
+export const QUERY_INSIGHTS_CHART_BUCKET_MS = 1_000;
+
+export interface QueryInsightsPrismaInfo {
+  action: string;
+  isRaw: boolean;
+  model?: string;
+  payload?: Record<string, unknown> | Array<Record<string, unknown>>;
+}
+
+export interface QueryInsightsQuery {
+  count: number;
+  duration: number;
+  groupKey?: string | null;
+  id: string;
+  lastSeen: number;
+  maxDurationMs?: number | null;
+  minDurationMs?: number | null;
+  prismaQueryInfo?: QueryInsightsPrismaInfo | null;
+  query: string;
+  queryId?: string | null;
+  reads: number;
+  rowsReturned: number;
+  tables: string[];
+}
+
+export interface QueryInsightsStreamQuery {
+  count: number;
+  durationMs: number;
+  groupKey?: string | null;
+  maxDurationMs?: number | null;
+  minDurationMs?: number | null;
+  prismaQueryInfo: QueryInsightsPrismaInfo | null;
+  queryId?: string | null;
+  reads: number;
+  rowsReturned: number;
+  sql: string;
+  tables: string[];
+  ts: number;
+}
+
+export interface QueryInsightsChartPoint {
+  avgDurationMs: number;
+  queryCount: number;
+  ts: number;
+}
+
+export interface QueryInsightsGroup {
+  avgDuration: number;
+  children: QueryInsightsQuery[];
+  groupKey: string;
+  lastSeen: number;
+  maxDuration: number;
+  minDuration: number;
+  prismaQueryInfo: QueryInsightsPrismaInfo;
+  tables: string[];
+  totalCount: number;
+  totalReads: number;
+  totalRows: number;
+}
+
+export type QueryInsightsDisplayRow =
+  | { group: QueryInsightsGroup; type: "group" }
+  | { query: QueryInsightsQuery; type: "standalone" };
+
+export type QueryInsightsSortField =
+  | "executions"
+  | "lastSeen"
+  | "latency"
+  | "reads";
+export type QueryInsightsSortDirection = "asc" | "desc";
+
+export interface QueryInsightsSortState {
+  direction: QueryInsightsSortDirection;
+  field: QueryInsightsSortField;
+}
+
+export const QUERY_INSIGHTS_DEFAULT_SORT: QueryInsightsSortState = {
+  direction: "desc",
+  field: "reads",
+};
+
+export interface QueryInsightsAnalyzeInput {
+  explainPlan?: string | null;
+  groupChildren?: Array<{
+    queryStats?: QueryInsightsAnalyzeStats | null;
+    rawQuery: string;
+  }> | null;
+  prismaQuery?: string | null;
+  prismaQueryInfo?: string | null;
+  queryStats?: QueryInsightsAnalyzeStats | null;
+  rawQuery: string;
+}
+
+export interface QueryInsightsAnalyzeStats {
+  count: number;
+  duration: number;
+  reads: number;
+  rowsReturned: number;
+}
+
+export interface QueryInsightsAnalysisResult {
+  analysisMarkdown: string;
+  confidenceScore?: number;
+  improvedPrisma?: string;
+  improvedSql?: string;
+  isOptimal: boolean;
+  issuesFound: string[];
+  recommendations: string[];
+}
+
+export interface QueryInsightsAnalyzeResponse {
+  error?: string | null;
+  result: QueryInsightsAnalysisResult | null;
+}
+
+export interface QueryInsightsUiEvent {
+  name:
+    | "studio:query_insights:ai_consent_accepted"
+    | "studio:query_insights:ai_consent_callout_viewed"
+    | "studio:query_insights:filter_applied"
+    | "studio:query_insights:output_copied"
+    | "studio:query_insights:query_detail_opened"
+    | "studio:query_insights:query_displayed"
+    | "studio:query_insights:sort_changed"
+    | "studio:query_insights:stream_error"
+    | "studio:query_insights:table_paused"
+    | "studio:query_insights:table_resumed"
+    | "studio:query_insights:viewed";
+  payload?: Record<string, unknown>;
+}

--- a/ui/studio/views/query-insights/use-query-insights-rows.ts
+++ b/ui/studio/views/query-insights/use-query-insights-rows.ts
@@ -1,0 +1,150 @@
+import { useCallback, useRef, useState } from "react";
+
+import { upsertQueryInsights, upsertQueryInsightsPauseBuffer } from "./rows";
+import {
+  QUERY_INSIGHTS_MAX_QUERIES,
+  QUERY_INSIGHTS_PAUSE_BUFFER_LIMIT,
+  type QueryInsightsQuery,
+  type QueryInsightsStreamQuery,
+} from "./types";
+
+export function useQueryInsightsRows() {
+  const [queriesMap, setQueriesMap] = useState<Map<string, QueryInsightsQuery>>(
+    new Map(),
+  );
+  const queriesMapRef = useRef(queriesMap);
+  const pauseBufferRef = useRef<Map<string, QueryInsightsQuery>>(new Map());
+  const [isPaused, setIsPaused] = useState(false);
+  const isPausedRef = useRef(false);
+  const [pauseBufferSize, setPauseBufferSize] = useState(0);
+  const [recentlyAddedIds, setRecentlyAddedIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [flushedIds, setFlushedIds] = useState<Set<string>>(new Set());
+  const recentlyAddedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  const flushedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearRecentlyAdded = useCallback(() => {
+    if (recentlyAddedTimeoutRef.current) {
+      clearTimeout(recentlyAddedTimeoutRef.current);
+    }
+
+    recentlyAddedTimeoutRef.current = setTimeout(() => {
+      setRecentlyAddedIds(new Set());
+      recentlyAddedTimeoutRef.current = null;
+    }, 600);
+  }, []);
+
+  const ingestQueries = useCallback(
+    (queries: QueryInsightsStreamQuery[]) => {
+      if (queries.length === 0) {
+        return;
+      }
+
+      if (isPausedRef.current) {
+        const nextBuffer = upsertQueryInsightsPauseBuffer(
+          pauseBufferRef.current,
+          queries,
+          QUERY_INSIGHTS_PAUSE_BUFFER_LIMIT,
+        );
+        pauseBufferRef.current = nextBuffer;
+        setPauseBufferSize(
+          Array.from(nextBuffer.values()).reduce(
+            (sum, query) => sum + query.count,
+            0,
+          ),
+        );
+        return;
+      }
+
+      setQueriesMap((current) => {
+        const { next, newIds } = upsertQueryInsights(
+          current,
+          queries,
+          QUERY_INSIGHTS_MAX_QUERIES,
+        );
+        queriesMapRef.current = next;
+
+        if (newIds.length > 0) {
+          setRecentlyAddedIds((previous) => {
+            const nextIds = new Set(previous);
+
+            for (const id of newIds) {
+              nextIds.add(id);
+            }
+
+            return nextIds;
+          });
+          clearRecentlyAdded();
+        }
+
+        return next;
+      });
+    },
+    [clearRecentlyAdded],
+  );
+
+  const pause = useCallback(() => {
+    isPausedRef.current = true;
+    setIsPaused(true);
+  }, []);
+
+  const resume = useCallback(() => {
+    const bufferedIds = new Set(pauseBufferRef.current.keys());
+
+    setQueriesMap((current) => {
+      const incomingRows = Array.from(pauseBufferRef.current.values()).map(
+        (query) => ({
+          count: query.count,
+          durationMs: query.duration,
+          groupKey: query.groupKey,
+          maxDurationMs: query.maxDurationMs,
+          minDurationMs: query.minDurationMs,
+          prismaQueryInfo: query.prismaQueryInfo ?? null,
+          queryId: query.queryId,
+          reads: query.reads,
+          rowsReturned: query.rowsReturned,
+          sql: query.query,
+          tables: query.tables,
+          ts: query.lastSeen,
+        }),
+      );
+      const { next } = upsertQueryInsights(
+        current,
+        incomingRows,
+        QUERY_INSIGHTS_MAX_QUERIES,
+      );
+      queriesMapRef.current = next;
+      return next;
+    });
+
+    pauseBufferRef.current = new Map();
+    setPauseBufferSize(0);
+    isPausedRef.current = false;
+    setIsPaused(false);
+    setFlushedIds(bufferedIds);
+
+    if (flushedTimeoutRef.current) {
+      clearTimeout(flushedTimeoutRef.current);
+    }
+
+    flushedTimeoutRef.current = setTimeout(() => {
+      setFlushedIds(new Set());
+      flushedTimeoutRef.current = null;
+    }, 1500);
+  }, []);
+
+  return {
+    flushedIds,
+    ingestQueries,
+    isAtLimit: queriesMap.size >= QUERY_INSIGHTS_MAX_QUERIES,
+    isPaused,
+    pause,
+    pauseBufferSize,
+    queries: Array.from(queriesMap.values()),
+    recentlyAddedIds,
+    resume,
+  };
+}

--- a/ui/studio/views/query-insights/use-query-insights-stream.test.tsx
+++ b/ui/studio/views/query-insights/use-query-insights-stream.test.tsx
@@ -1,0 +1,285 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  QueryInsightsChartPoint,
+  QueryInsightsStreamQuery,
+} from "./types";
+import { useQueryInsightsStream } from "./use-query-insights-stream";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const STREAM_URL =
+  "/api/streams/v1/stream/prisma-log?format=json&live=sse&offset=-1&timeout=30s";
+
+type EventSourceCallback = (event: Event) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly listeners = new Map<
+    string,
+    Set<EventListenerOrEventListenerObject>
+  >();
+  readonly url: string;
+  closed = false;
+  onerror: EventSourceCallback | null = null;
+  onmessage: EventSourceCallback | null = null;
+  onopen: EventSourceCallback | null = null;
+  readyState = 0;
+  withCredentials = false;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+  ) {
+    if (!listener) {
+      return;
+    }
+
+    const listeners = this.listeners.get(type) ?? new Set();
+
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  dispatchEvent(event: Event): boolean {
+    const listeners = this.listeners.get(event.type) ?? new Set();
+
+    for (const listener of listeners) {
+      if (typeof listener === "function") {
+        listener.call(this, event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+
+    return true;
+  }
+
+  emit(type: string, data: string) {
+    this.dispatchEvent(new MessageEvent(type, { data }));
+  }
+
+  open() {
+    this.readyState = 1;
+    this.onopen?.(new Event("open"));
+  }
+
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+  ) {
+    if (!listener) {
+      return;
+    }
+
+    this.listeners.get(type)?.delete(listener);
+  }
+}
+
+function createStreamQuery(
+  overrides: Partial<QueryInsightsStreamQuery> = {},
+): QueryInsightsStreamQuery {
+  return {
+    count: 1,
+    durationMs: 8,
+    groupKey: null,
+    maxDurationMs: 8,
+    minDurationMs: 8,
+    prismaQueryInfo: null,
+    queryId: null,
+    reads: 0,
+    rowsReturned: 1,
+    sql: "select * from organizations",
+    tables: ["organizations"],
+    ts: 1_700_000_000_000,
+    visibility: "studio-system",
+    ...overrides,
+  };
+}
+
+function renderHarness(args?: { streamUrl?: string }) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const onChartTicks = vi.fn<(points: QueryInsightsChartPoint[]) => void>();
+  const onError = vi.fn<(message: string) => void>();
+  const onQueries = vi.fn<(queries: QueryInsightsStreamQuery[]) => void>();
+
+  document.body.appendChild(container);
+
+  function Harness() {
+    useQueryInsightsStream({
+      onChartTicks,
+      onError,
+      onQueries,
+      streamUrl: args?.streamUrl ?? STREAM_URL,
+    });
+
+    return null;
+  }
+
+  act(() => {
+    root.render(<Harness />);
+  });
+
+  return {
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+    onChartTicks,
+    onError,
+    onQueries,
+  };
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const timeoutMs = 2_000;
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (assertion()) {
+      return;
+    }
+
+    await flush();
+  }
+
+  throw new Error("Timed out waiting for Query Insights stream state");
+}
+
+describe("useQueryInsightsStream", () => {
+  let originalEventSource: typeof EventSource | undefined;
+
+  beforeEach(() => {
+    originalEventSource = globalThis.EventSource;
+    MockEventSource.instances = [];
+    Object.defineProperty(globalThis, "EventSource", {
+      configurable: true,
+      value: MockEventSource,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "EventSource", {
+      configurable: true,
+      value: originalEventSource,
+    });
+    document.body.innerHTML = "";
+  });
+
+  it("loads an initial prisma-log snapshot before subscribing to live rows", async () => {
+    const query = createStreamQuery();
+    const logEvent = {
+      ...query,
+      type: "query",
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify([logEvent]), {
+        headers: {
+          "content-type": "application/json",
+          "stream-next-offset": "0000000000000000003G000000",
+        },
+      }),
+    );
+    const harness = renderHarness();
+
+    await waitFor(
+      () =>
+        harness.onQueries.mock.calls.length === 1 &&
+        MockEventSource.instances.length === 1,
+    );
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+      "/api/streams/v1/stream/prisma-log?format=json&offset=-1",
+    );
+    expect(fetchSpy.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: {
+          accept: "application/json",
+        },
+      }),
+    );
+    expect(fetchSpy.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    expect(harness.onQueries).toHaveBeenCalledWith([query]);
+    expect(harness.onChartTicks).toHaveBeenCalledWith([
+      {
+        avgDurationMs: 8,
+        queryCount: 1,
+        ts: 1_700_000_000_000,
+      },
+    ]);
+    expect(MockEventSource.instances[0]?.url).toBe(
+      "/api/streams/v1/stream/prisma-log?format=json&live=sse&offset=0000000000000000003G000000&timeout=30s",
+    );
+    expect(harness.onError).not.toHaveBeenCalled();
+
+    harness.cleanup();
+  });
+
+  it("keeps live streaming when the initial snapshot is empty", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", {
+        headers: {
+          "stream-next-offset": "00000000000000000000000000",
+        },
+      }),
+    );
+    const harness = renderHarness();
+
+    await waitFor(() => MockEventSource.instances.length === 1);
+
+    const liveQuery = createStreamQuery({
+      durationMs: 12,
+      sql: "select * from incidents",
+      tables: ["incidents"],
+      ts: 1_700_000_001_000,
+    });
+    const liveLogEvent = {
+      ...liveQuery,
+      type: "query",
+    };
+
+    act(() => {
+      MockEventSource.instances[0]?.emit(
+        "data",
+        JSON.stringify([liveLogEvent]),
+      );
+    });
+
+    expect(harness.onQueries).toHaveBeenCalledWith([liveQuery]);
+    expect(harness.onChartTicks).toHaveBeenCalledWith([
+      {
+        avgDurationMs: 12,
+        queryCount: 1,
+        ts: 1_700_000_001_000,
+      },
+    ]);
+    expect(harness.onError).not.toHaveBeenCalled();
+
+    harness.cleanup();
+  });
+});

--- a/ui/studio/views/query-insights/use-query-insights-stream.ts
+++ b/ui/studio/views/query-insights/use-query-insights-stream.ts
@@ -17,6 +17,40 @@ export type QueryInsightsStreamStatus =
   | "error"
   | "open";
 
+function createBrowserUrl(
+  rawUrl: string,
+  updateSearchParams: (searchParams: URLSearchParams) => void,
+): string {
+  const baseUrl =
+    typeof window === "undefined" ? "http://localhost" : window.location.origin;
+  const url = new URL(rawUrl, `${baseUrl}/`);
+
+  updateSearchParams(url.searchParams);
+
+  if (/^https?:\/\//i.test(rawUrl)) {
+    return url.toString();
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function createInitialSnapshotUrl(streamUrl: string): string {
+  return createBrowserUrl(streamUrl, (searchParams) => {
+    searchParams.delete("live");
+    searchParams.delete("timeout");
+  });
+}
+
+function createLiveStreamUrl(streamUrl: string, offset: string | null): string {
+  if (!offset) {
+    return streamUrl;
+  }
+
+  return createBrowserUrl(streamUrl, (searchParams) => {
+    searchParams.set("offset", offset);
+  });
+}
+
 export function useQueryInsightsStream(args: {
   onChartTicks: (points: QueryInsightsChartPoint[]) => void;
   onError: (message: string) => void;
@@ -40,15 +74,9 @@ export function useQueryInsightsStream(args: {
 
     setStatus("connecting");
 
-    const eventSource = new EventSource(streamUrl);
-
-    eventSource.onopen = () => {
-      setStatus("open");
-    };
-    eventSource.onerror = () => {
-      setStatus("error");
-      onError("The Query Insights stream disconnected.");
-    };
+    const abortController = new AbortController();
+    let eventSource: EventSource | null = null;
+    let isDisposed = false;
 
     const handleQueries = (event: MessageEvent<string>) => {
       const decoded = safeDecodeQueriesEvent(event.data);
@@ -95,6 +123,20 @@ export function useQueryInsightsStream(args: {
       }
     };
 
+    const handlePrismaLogQueries = (queries: QueryInsightsStreamQuery[]) => {
+      if (queries.length === 0) {
+        return;
+      }
+
+      onQueries(queries);
+
+      const chartTicks = createChartTicksFromQueries(queries);
+
+      if (chartTicks.length > 0) {
+        onChartTicks(chartTicks);
+      }
+    };
+
     const handleStreamError = (event: Event) => {
       const message =
         event instanceof MessageEvent && typeof event.data === "string"
@@ -104,17 +146,83 @@ export function useQueryInsightsStream(args: {
       onError(message);
     };
 
-    eventSource.addEventListener("queries", handleQueries);
-    eventSource.addEventListener("chartTick", handleChartTick);
-    eventSource.addEventListener("data", handlePrismaLogData);
-    eventSource.addEventListener("error", handleStreamError);
+    const openEventSource = (liveStreamUrl: string) => {
+      if (isDisposed) {
+        return;
+      }
+
+      eventSource = new EventSource(liveStreamUrl);
+
+      eventSource.onopen = () => {
+        setStatus("open");
+      };
+      eventSource.onerror = () => {
+        setStatus("error");
+        onError("The Query Insights stream disconnected.");
+      };
+
+      eventSource.addEventListener("queries", handleQueries);
+      eventSource.addEventListener("chartTick", handleChartTick);
+      eventSource.addEventListener("data", handlePrismaLogData);
+      eventSource.addEventListener("error", handleStreamError);
+    };
+
+    void (async () => {
+      let nextOffset: string | null = null;
+
+      try {
+        const response = await fetch(createInitialSnapshotUrl(streamUrl), {
+          headers: {
+            accept: "application/json",
+          },
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `Could not load Query Insights snapshot (${response.status}).`,
+          );
+        }
+
+        const text = await response.text();
+        const decoded = safeDecodePrismaLogDataEvent(
+          text.trim().length > 0 ? text : "[]",
+        );
+
+        if (!decoded.success || !decoded.data) {
+          throw decoded.error ?? new Error("Could not decode prisma-log rows.");
+        }
+
+        if (!isDisposed) {
+          handlePrismaLogQueries(decoded.data);
+          nextOffset =
+            response.headers.get("stream-next-offset") ??
+            response.headers.get("Stream-Next-Offset");
+        }
+      } catch (error) {
+        if (abortController.signal.aborted || isDisposed) {
+          return;
+        }
+
+        onError(
+          error instanceof Error
+            ? error.message
+            : "Could not load Query Insights snapshot.",
+        );
+      }
+
+      openEventSource(createLiveStreamUrl(streamUrl, nextOffset));
+    })();
 
     return () => {
-      eventSource.removeEventListener("queries", handleQueries);
-      eventSource.removeEventListener("chartTick", handleChartTick);
-      eventSource.removeEventListener("data", handlePrismaLogData);
-      eventSource.removeEventListener("error", handleStreamError);
-      eventSource.close();
+      isDisposed = true;
+      abortController.abort();
+
+      eventSource?.removeEventListener("queries", handleQueries);
+      eventSource?.removeEventListener("chartTick", handleChartTick);
+      eventSource?.removeEventListener("data", handlePrismaLogData);
+      eventSource?.removeEventListener("error", handleStreamError);
+      eventSource?.close();
       setStatus("closed");
     };
   }, [onChartTicks, onError, onQueries, streamUrl]);

--- a/ui/studio/views/query-insights/use-query-insights-stream.ts
+++ b/ui/studio/views/query-insights/use-query-insights-stream.ts
@@ -1,0 +1,123 @@
+import { useEffect, useState } from "react";
+
+import {
+  createChartTicksFromQueries,
+  safeDecodeChartTickEvent,
+  safeDecodePrismaLogDataEvent,
+  safeDecodeQueriesEvent,
+} from "./codecs";
+import type {
+  QueryInsightsChartPoint,
+  QueryInsightsStreamQuery,
+} from "./types";
+
+export type QueryInsightsStreamStatus =
+  | "closed"
+  | "connecting"
+  | "error"
+  | "open";
+
+export function useQueryInsightsStream(args: {
+  onChartTicks: (points: QueryInsightsChartPoint[]) => void;
+  onError: (message: string) => void;
+  onQueries: (queries: QueryInsightsStreamQuery[]) => void;
+  streamUrl: string;
+}) {
+  const { onChartTicks, onError, onQueries, streamUrl } = args;
+  const [status, setStatus] = useState<QueryInsightsStreamStatus>("connecting");
+
+  useEffect(() => {
+    if (streamUrl.trim().length === 0) {
+      setStatus("closed");
+      return;
+    }
+
+    if (typeof EventSource !== "function") {
+      setStatus("error");
+      onError("EventSource is not available in this browser.");
+      return;
+    }
+
+    setStatus("connecting");
+
+    const eventSource = new EventSource(streamUrl);
+
+    eventSource.onopen = () => {
+      setStatus("open");
+    };
+    eventSource.onerror = () => {
+      setStatus("error");
+      onError("The Query Insights stream disconnected.");
+    };
+
+    const handleQueries = (event: MessageEvent<string>) => {
+      const decoded = safeDecodeQueriesEvent(event.data);
+
+      if (!decoded.success || !decoded.data) {
+        onError(decoded.error?.message ?? "Could not decode query events.");
+        return;
+      }
+
+      onQueries(decoded.data);
+    };
+
+    const handleChartTick = (event: MessageEvent<string>) => {
+      const decoded = safeDecodeChartTickEvent(event.data);
+
+      if (!decoded.success || !decoded.data) {
+        onError(decoded.error?.message ?? "Could not decode chart events.");
+        return;
+      }
+
+      onChartTicks([decoded.data]);
+    };
+
+    const handlePrismaLogData = (event: MessageEvent<string>) => {
+      const decoded = safeDecodePrismaLogDataEvent(event.data);
+
+      if (!decoded.success || !decoded.data) {
+        onError(
+          decoded.error?.message ?? "Could not decode prisma-log events.",
+        );
+        return;
+      }
+
+      if (decoded.data.length === 0) {
+        return;
+      }
+
+      onQueries(decoded.data);
+
+      const chartTicks = createChartTicksFromQueries(decoded.data);
+
+      if (chartTicks.length > 0) {
+        onChartTicks(chartTicks);
+      }
+    };
+
+    const handleStreamError = (event: Event) => {
+      const message =
+        event instanceof MessageEvent && typeof event.data === "string"
+          ? event.data
+          : "Query Insights backend reported an error.";
+
+      onError(message);
+    };
+
+    eventSource.addEventListener("queries", handleQueries);
+    eventSource.addEventListener("chartTick", handleChartTick);
+    eventSource.addEventListener("data", handlePrismaLogData);
+    eventSource.addEventListener("error", handleStreamError);
+
+    return () => {
+      eventSource.removeEventListener("queries", handleQueries);
+      eventSource.removeEventListener("chartTick", handleChartTick);
+      eventSource.removeEventListener("data", handlePrismaLogData);
+      eventSource.removeEventListener("error", handleStreamError);
+      eventSource.close();
+      setStatus("closed");
+    };
+  }, [onChartTicks, onError, onQueries, streamUrl]);
+
+  return { status };
+}


### PR DESCRIPTION
## Summary

- Adds the host-provided Query Insights Studio view, including `prisma-log` stream ingestion with initial snapshot replay plus live SSE follow, charted latency/QPS metrics, table filtering/sorting, pause buffering, and the right-side AI recommendation sheet.
- Wires the ppg-dev demo to ensure and append every successful SQL execution into the `prisma-log` stream, with Studio system queries classified via visibility metadata instead of filtered out.
- Makes stream event time rendering understand `ts` epoch fields, so `prisma-log` rows show real relative/exact times in the Streams view.
- Adds Query Insights architecture docs, feature docs, changeset, URL state, navigation/command palette integration, and focused coverage.
- Includes two review fixes needed for local CI signal: current `@prisma/dev` runtime assets no longer include `pglite-seed.tar.gz`, and the TanStack DB architecture allowlist now includes the existing stream-events collection boundary.

## Validation

- `git diff --check`
- `pnpm typecheck`
- `pnpm build`
- `COREPACK_ENABLE_STRICT=0 pnpm check:exports`
- `pnpm test:data`
- `pnpm test:demo`
- `pnpm test:checkpoint`
- `pnpm exec vitest --project release`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec vitest --passWithNoTests --project ui --maxWorkers=2 --exclude ui/studio/views/table/ActiveTableView.filtering.test.tsx`
- `git ls-files -m -o --exclude-standard | rg '\.(ts|tsx)$' | xargs pnpm exec eslint` (warnings only from existing `data/query.ts` `any` usage)
- `pnpm test demo/ppg-dev/query-insights.test.ts ui/studio/views/query-insights/codecs.test.ts ui/studio/views/query-insights/rows.test.ts`
- `pnpm exec eslint demo/ppg-dev/query-insights.ts demo/ppg-dev/query-insights.test.ts ui/studio/views/query-insights/types.ts ui/studio/views/query-insights/codecs.ts ui/studio/views/query-insights/codecs.test.ts ui/studio/views/query-insights/rows.ts ui/studio/views/query-insights/rows.test.ts`
- `pnpm test ui/studio/views/query-insights/use-query-insights-stream.test.tsx ui/studio/views/query-insights/codecs.test.ts ui/studio/views/query-insights/rows.test.ts ui/hooks/use-stream-events.test.tsx demo/ppg-dev/query-insights.test.ts`
- `pnpm exec eslint ui/studio/views/query-insights/use-query-insights-stream.ts ui/studio/views/query-insights/use-query-insights-stream.test.tsx ui/hooks/use-stream-events.ts ui/hooks/use-stream-events.test.tsx`
- `pnpm test ui/studio/views/query-insights/QueryInsightsView.test.tsx ui/studio/views/query-insights/use-query-insights-stream.test.tsx`
- `pnpm demo:ppg`, then `POST /api/query` with `meta.visibility = "studio-system"` and `GET /api/streams/v1/stream/prisma-log?format=json&offset=-1` to verify Studio system executions are appended with `visibility: "studio-system"`.
- Playwright smoke against `http://localhost:4310/#view=query-insights` verified Query Insights populates immediately from the existing `prisma-log` snapshot.
- Playwright smoke against `http://localhost:4310/#stream=prisma-log&view=stream` verified `ts`-backed rows render relative/exact times instead of `Unknown time`.
- Playwright smoke was run during implementation for Query Insights stream ingestion, charts, table corner, select font, and AI detail sheet.

## Notes

A full all-project `pnpm test` run was attempted after stopping the demo server. It progressed through the suite but the existing `ui/studio/views/table/ActiveTableView.filtering.test.tsx` file spins a Vitest worker into high CPU/heap when run as a whole. The changed Query Insights/UI/data/demo/release/checkpoint paths pass with the targeted commands above.
