### PR TITLE
[codex] Fix Safari grid horizontal scrolling

### DIFF
--- a/ui/components/ui/table.tsx
+++ b/ui/components/ui/table.tsx
@@ -15,7 +15,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
     return (
       <div
         className={cn(
-          "relative w-full overflow-auto flex items-start h-full",
+          "relative h-full w-full min-w-0 overflow-auto",
           containerClassName,
         )}
         {...resolvedContainerProps}

--- a/ui/studio/grid/DataGrid.layout.test.tsx
+++ b/ui/studio/grid/DataGrid.layout.test.tsx
@@ -4,7 +4,7 @@ import type {
 } from "@tanstack/react-table";
 import { act, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DataGrid } from "./DataGrid";
 import { createReadOnlyColumns, type GridRow } from "./test-utils";
@@ -13,10 +13,47 @@ import { createReadOnlyColumns, type GridRow } from "./test-utils";
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+beforeEach(() => {
+  const localStorage = createLocalStorageMock();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorage,
+  });
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: localStorage,
+  });
+});
+
 afterEach(() => {
   vi.restoreAllMocks();
   document.body.innerHTML = "";
 });
+
+function createLocalStorageMock(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key: string) {
+      return entries.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, value);
+    },
+  };
+}
 
 function renderGrid(rows: GridRow[]) {
   const container = document.createElement("div");
@@ -83,6 +120,24 @@ describe("DataGrid layout", () => {
 
     expect(table.style.width).toBe("435px");
     expect(table.style.minWidth).toBe("100%");
+
+    cleanup();
+  });
+
+  it("keeps the table wrapper as a plain overflow scroller for wide-grid horizontal scrolling", () => {
+    const { cleanup, table } = renderGrid([
+      {
+        __ps_rowid: "row_1",
+        long_text: "wide",
+        short_text: "Acme Labs",
+      },
+    ]);
+    const scrollContainer = table.parentElement;
+
+    expect(scrollContainer).toBeInstanceOf(HTMLDivElement);
+    expect(scrollContainer?.className).toContain("overflow-auto");
+    expect(scrollContainer?.className).toContain("min-w-0");
+    expect(scrollContainer?.className).not.toContain("flex");
 
     cleanup();
   });


### PR DESCRIPTION
## Summary

Fixes horizontal scrolling in Prisma Studio wide grids on Safari by keeping the shared table wrapper as a plain overflow scroller instead of making the scroll container itself a flex formatting context.

## Root Cause

The grid table already pins its width to the computed column sizes. The wrapper around that table also had `display: flex`, which Chromium tolerated, but Safari can fail to expose the expected horizontal scroll range for wide table content inside an overflow flex container.

## Changes

- Remove `flex items-start` from the shared table wrapper.
- Add `min-w-0` so the overflow container can shrink inside Studio's flex layout while preserving horizontal overflow.
- Add a DataGrid layout regression test asserting the wrapper remains a plain `overflow-auto` scroller.
- Add a localStorage mock in that test file so it runs reliably in this Node/happy-dom setup.

## Validation

- `pnpm test:ui ui/studio/grid/DataGrid.layout.test.tsx`
- Manual browser check with `pnpm demo:ppg` at `http://localhost:4310` using the seeded `public.all_data_types` table.
- Captured screenshots at the left edge and after horizontal scroll; the later screenshot shows the grid successfully scrolled to later columns (`double_col`, `inet_col`).

Note: `pnpm test:ui ui/studio/grid/DataGrid.virtualization.test.tsx` currently fails before assertions in this checkout because `globalThis.localStorage` lacks `getItem` in that test environment. The focused layout test includes a local mock and passes.