### PR TITLE
Fix trusted publishing repository metadata

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@ This repository supports two release paths. Both publish from `main`, use npm tr
 
 Configure `@prisma/studio-core` in npm as a trusted publisher for the `prisma/studio` GitHub repository and the publish workflow. The workflow does not use `NPM_TOKEN`.
 
+Keep `package.json` `repository.url` set to `https://github.com/prisma/studio`. npm validates that package metadata against the GitHub Actions provenance bundle during trusted publishing.
+
 ## Path 1: Changesets Release PR
 
 Use this path for normal releases.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@prisma/studio-core",
   "version": "0.28.0",
   "description": "Modular Prisma Studio components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/studio"
+  },
   "type": "module",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
## Summary

- set `package.json` `repository.url` to `https://github.com/prisma/studio`
- document why the field must match the trusted publishing provenance repository

## Why

The `@prisma/studio-core@0.28.0` publish workflow built and passed export validation, but npm rejected trusted publishing provenance because `package.json` did not include a matching repository URL.

## Validation

- `pnpm release:prepare`
- `git diff --check`
