### PR TITLE
Fix duplicate startup introspection requests

### DIFF
--- a/.changeset/bright-dragons-introspect-once.md
+++ b/.changeset/bright-dragons-introspect-once.md
@@ -2,4 +2,6 @@
 "@prisma/studio-core": minor
 ---
 
+# Fix duplicate startup introspection requests
+
 Avoid cancelling and repeating introspection requests when Studio initially mounts.

--- a/.changeset/bright-dragons-introspect-once.md
+++ b/.changeset/bright-dragons-introspect-once.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": minor
+---
+
+Avoid cancelling and repeating introspection requests when Studio initially mounts.

--- a/Architecture/introspection.md
+++ b/Architecture/introspection.md
@@ -87,6 +87,7 @@ Failure diagnostics MUST include:
 
 Changes to this subsystem MUST include tests for:
 
+- a single initial introspection without mount-time cancellation or refetch
 - failed initial introspection without automatic retry
 - stale-data preservation after a failed refetch
 - startup recovery UI rendering

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,6 +9,7 @@ Each adapter handles introspection, querying, inserts, updates, and deletes whil
 
 Studio introspects connected databases to build schemas, tables, columns, relationships, filter operators, and timezone metadata.
 This gives users an accurate live model of the database and keeps table navigation grounded in current structure.
+A fresh Studio mount performs this discovery once, while actual adapter or database-availability changes invalidate cached metadata and load it again.
 
 ## Deployable Prisma Postgres Demo
 

--- a/ui/studio/context.test.tsx
+++ b/ui/studio/context.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -50,10 +51,20 @@ function createAdapter(): Adapter {
   } as unknown as Adapter;
 }
 
-function renderHarness(props?: { streamsUrl?: string }) {
+type RenderHarnessProps = {
+  adapter?: Adapter;
+  hasDatabase?: boolean;
+  streamsUrl?: string;
+};
+
+function renderHarness(props?: RenderHarnessProps) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
+  let currentProps = {
+    ...props,
+    adapter: props?.adapter ?? createAdapter(),
+  };
 
   let latestStudio: ReturnType<typeof useStudio> | undefined;
 
@@ -62,15 +73,20 @@ function renderHarness(props?: { streamsUrl?: string }) {
     return null;
   }
 
-  act(() => {
+  function render() {
     root.render(
       <StudioContextProvider
-        adapter={createAdapter()}
-        streamsUrl={props?.streamsUrl}
+        adapter={currentProps.adapter}
+        hasDatabase={currentProps.hasDatabase}
+        streamsUrl={currentProps.streamsUrl}
       >
         <Harness />
       </StudioContextProvider>,
     );
+  }
+
+  act(() => {
+    render();
   });
 
   return {
@@ -82,6 +98,16 @@ function renderHarness(props?: { streamsUrl?: string }) {
     },
     getLatestStudio() {
       return latestStudio;
+    },
+    rerender(nextProps: RenderHarnessProps) {
+      currentProps = {
+        ...currentProps,
+        ...nextProps,
+      };
+
+      act(() => {
+        render();
+      });
     },
   };
 }
@@ -168,6 +194,30 @@ afterEach(() => {
   delete process.env.CHECKPOINT_DISABLE;
   delete (globalThis as { VERSION_INJECTED_AT_BUILD_TIME?: string })
     .VERSION_INJECTED_AT_BUILD_TIME;
+});
+
+describe("StudioContextProvider database cache lifecycle", () => {
+  it("resets cached queries only after the database configuration changes", () => {
+    const resetQueriesSpy = vi
+      .spyOn(QueryClient.prototype, "resetQueries")
+      .mockResolvedValue();
+    const initialAdapter = createAdapter();
+    const harness = renderHarness({ adapter: initialAdapter });
+
+    try {
+      expect(resetQueriesSpy).not.toHaveBeenCalled();
+
+      const nextAdapter = createAdapter();
+      harness.rerender({ adapter: nextAdapter });
+      expect(resetQueriesSpy).toHaveBeenCalledTimes(1);
+
+      harness.rerender({ adapter: nextAdapter, hasDatabase: false });
+      expect(resetQueriesSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      harness.cleanup();
+      resetQueriesSpy.mockRestore();
+    }
+  });
 });
 
 describe("StudioContextProvider pagination preferences", () => {

--- a/ui/studio/context.test.tsx
+++ b/ui/studio/context.test.tsx
@@ -211,6 +211,9 @@ describe("StudioContextProvider database cache lifecycle", () => {
       harness.rerender({ adapter: nextAdapter });
       expect(resetQueriesSpy).toHaveBeenCalledTimes(1);
 
+      harness.rerender({ adapter: nextAdapter });
+      expect(resetQueriesSpy).toHaveBeenCalledTimes(1);
+
       harness.rerender({ adapter: nextAdapter, hasDatabase: false });
       expect(resetQueriesSpy).toHaveBeenCalledTimes(2);
     } finally {

--- a/ui/studio/context.tsx
+++ b/ui/studio/context.tsx
@@ -317,6 +317,7 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
   } = props;
 
   const queryClientRef = useRef(new QueryClient());
+  const previousDatabaseConfigRef = useRef({ adapter, hasDatabase });
   const signatureRef = useRef(shortUUID.generate());
   const rowsCollectionCacheRef = useRef(new Map<string, unknown>());
   const tableQueryExecutionStateCacheRef = useRef(
@@ -526,7 +527,17 @@ export function StudioContextProvider(props: StudioContextProviderProps) {
   }, [studioUiCollection]);
 
   useEffect(() => {
-    // if the adapter has been changed, then we need to reload
+    const previousDatabaseConfig = previousDatabaseConfigRef.current;
+    previousDatabaseConfigRef.current = { adapter, hasDatabase };
+
+    if (
+      previousDatabaseConfig.adapter === adapter &&
+      previousDatabaseConfig.hasDatabase === hasDatabase
+    ) {
+      return;
+    }
+
+    // If the database configuration changed, then we need to reload.
     for (const state of tableQueryExecutionStateCacheRef.current.values()) {
       state.activeController?.abort();
     }


### PR DESCRIPTION
## Summary

- avoid resetting a fresh query client when `StudioContextProvider` first mounts
- retain cache invalidation when the adapter or database availability actually changes
- document and test the single-introspection startup contract
- add a minor changeset for `@prisma/studio-core` 0.33.0

## Root cause

The database-configuration effect ran on the initial mount and called `queryClient.resetQueries()`. Child introspection queries had already started, so TanStack Query cancelled both BFF requests and immediately issued them again. Prisma ORM's Node server surfaced the cancelled response pipelines as `ERR_STREAM_PREMATURE_CLOSE`.

## Validation

- `pnpm typecheck`
- `pnpm lint` (passes with existing repository warnings)
- `pnpm test:ui` — 624 passed
- `pnpm test` — 908 passed, 38 skipped
- `pnpm build`
- `pnpm check:exports`
- `pnpm changeset status` — minor bump to 0.33.0
- `pnpm demo:ppg` + Playwright at `http://localhost:4310`
  - initial introspection table and timezone requests each completed once with HTTP 200
  - no aborted startup requests or server errors
  - Migrations viewer loaded all 20 seeded Prisma Next migrations
