### PR TITLE
fix: SQLite date-like column edits producing NaN

### DIFF
--- a/.changeset/sqlite-date-like-columns-text.md
+++ b/.changeset/sqlite-date-like-columns-text.md
@@ -1,0 +1,7 @@
+---
+"@prisma/studio-core": patch
+---
+
+# Fix SQLite date-like column edits producing NaN
+
+SQLite columns declared as `date`, `datetime`, or `timestamp` get NUMERIC affinity, so Studio treated their date-string values as numbers and coerced edits to `NaN`. Date-like declared types are now edited as text and stored as-is, and numeric cell edits, pastes, and filters only coerce input to a number when it actually parses as one — non-numeric text is kept as text, matching SQLite's NUMERIC-affinity semantics, so `NaN` is never written.

--- a/Architecture/cell-editing.md
+++ b/Architecture/cell-editing.md
@@ -95,6 +95,7 @@ Required semantics:
 - The inline editor popover MUST keep the cancel action but MUST NOT expose a per-cell save button once table-level staging is enabled.
 - Staging should only submit when value changed according to component rules.
 - Empty value semantics (`NULL`, default, empty string) MUST be explicit and type-aware per input component.
+- `NumericInput` (and numeric value coercion in paste/filter paths) MUST never stage `NaN`: input is only coerced to a number when it parses as one, otherwise the raw text is staged (SQLite NUMERIC-affinity columns store it as TEXT per affinity rules; stricter engines reject it with a clear error). SQLite columns with date-like declared types (`date`, `datetime`, `timestamp`) are introspected with group `string` so they edit as text in the first place.
 
 ## Focused-Cell Contract
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -277,6 +277,8 @@ Editable cells open popover editors with datatype-specific controls for raw text
 Save/cancel keyboard behavior is standardized, and null/default/empty semantics are handled explicitly per input type.
 Native PostgreSQL arrays can be edited from JSON-style array values and are written back with explicit array casts when inline SQL literals are required.
 PostgreSQL user-defined enum arrays also persist through that same staged-edit flow, with schema-qualified casts emitted in a form PostgreSQL accepts for `enum[]` writes.
+SQLite columns with date-like declared types (`date`, `datetime`, `timestamp`) are edited as text and stored as-is despite their NUMERIC affinity, matching how SQLite itself stores date strings.
+Numeric editing never writes `NaN`: input is only coerced to a number when it actually parses as one, and non-numeric text is passed through so SQLite NUMERIC-affinity columns keep it as text while stricter databases reject it with a clear error.
 
 ## Staged Multi-Cell Editing
 

--- a/data/sqlite-core/adapter.test.ts
+++ b/data/sqlite-core/adapter.test.ts
@@ -226,7 +226,7 @@ describe("sqlite-core/adapter", () => {
                       "date": {
                         "datatype": {
                           "affinity": "NUMERIC",
-                          "group": "numeric",
+                          "group": "string",
                           "isArray": false,
                           "isNative": true,
                           "name": "date",
@@ -249,7 +249,7 @@ describe("sqlite-core/adapter", () => {
                       "datetime": {
                         "datatype": {
                           "affinity": "NUMERIC",
-                          "group": "numeric",
+                          "group": "string",
                           "isArray": false,
                           "isNative": true,
                           "name": "datetime",
@@ -936,6 +936,64 @@ describe("sqlite-core/adapter", () => {
           },
         ]
       `);
+    });
+  });
+
+  describe("update", () => {
+    it("stores date-like strings as text in NUMERIC-affinity date columns", async () => {
+      database.exec('DELETE FROM "animals" WHERE "id" = 201');
+      database.exec(`
+        INSERT INTO "animals" ("id", "name", "datetime")
+        VALUES (201, 'capybara', '2021-11-01 21:30:00')
+      `);
+
+      const [introspectionError, introspection] = await adapter.introspect({});
+
+      expect(introspectionError).toBeNull();
+
+      const table = introspection?.schemas.main?.tables?.animals;
+
+      if (!table) {
+        throw new Error("Expected main.animals table in introspection");
+      }
+
+      // date-like declared types are edited as text, not numbers.
+      expect(table.columns.datetime?.datatype).toMatchObject({
+        affinity: "NUMERIC",
+        group: "string",
+      });
+
+      try {
+        const [error, result] = await adapter.update(
+          {
+            changes: { datetime: "2021-11-01 22:30:00" },
+            row: { id: 201 },
+            table,
+          },
+          {},
+        );
+
+        expect(error).toBeNull();
+        expect(result?.row).toEqual(
+          expect.objectContaining({
+            datetime: "2021-11-01 22:30:00",
+            id: 201,
+          }),
+        );
+
+        const stored = database
+          .prepare(
+            'SELECT "datetime", typeof("datetime") as "type" FROM "animals" WHERE "id" = 201',
+          )
+          .get() as { datetime: string; type: string };
+
+        expect(stored).toEqual({
+          datetime: "2021-11-01 22:30:00",
+          type: "text",
+        });
+      } finally {
+        database.exec('DELETE FROM "animals" WHERE "id" = 201');
+      }
     });
   });
 

--- a/data/sqlite-core/adapter.ts
+++ b/data/sqlite-core/adapter.ts
@@ -23,10 +23,7 @@ import {
 import { asQuery, type Query, type QueryResult } from "../query";
 import { createSqlEditorSchemaFromIntrospection } from "../sql-editor-schema";
 import type { Either } from "../type-utils";
-import {
-  determineColumnAffinity,
-  SQLITE_AFFINITY_TO_METADATA,
-} from "./datatype";
+import { determineColumnMetadata } from "./datatype";
 import {
   getDeleteQuery,
   getInsertQuery,
@@ -394,7 +391,7 @@ function createIntrospection(args: {
 
             maxPKSeen = Math.max(maxPKSeen, pk);
 
-            const affinity = determineColumnAffinity(datatype);
+            const metadata = determineColumnMetadata(datatype);
 
             /**
              * `INTEGER PRIMARY KEY` columns act as `rowid` alias. `rowid` columns
@@ -419,8 +416,7 @@ function createIntrospection(args: {
 
             columnsRecord[columnName] = {
               datatype: {
-                ...SQLITE_AFFINITY_TO_METADATA[affinity],
-                affinity,
+                ...metadata,
                 isArray: false,
                 isNative: true,
                 name: datatype,

--- a/data/sqlite-core/datatype.test.ts
+++ b/data/sqlite-core/datatype.test.ts
@@ -70,6 +70,34 @@ describe("determineColumnMetadata", () => {
       expected: { affinity: "NUMERIC", group: "string" },
     },
     { datatype: "TIME", expected: { affinity: "NUMERIC", group: "string" } },
+    {
+      datatype: "DATETIME(6)",
+      expected: { affinity: "NUMERIC", group: "string" },
+    },
+    {
+      datatype: "TIMESTAMP WITH TIME ZONE",
+      expected: { affinity: "NUMERIC", group: "string" },
+    },
+
+    // NUMERIC-affinity declared types that merely contain a date/time
+    // substring are not date-like and stay numeric.
+    {
+      datatype: "CANDIDATE",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
+    { datatype: "DATED", expected: { affinity: "NUMERIC", group: "numeric" } },
+    {
+      datatype: "RUNTIME",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
+    {
+      datatype: "LIFETIME",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
+    {
+      datatype: "TIMES",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
 
     // other NUMERIC affinity declared types stay numeric.
     {

--- a/data/sqlite-core/datatype.test.ts
+++ b/data/sqlite-core/datatype.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { determineColumnAffinity } from "./datatype";
+import { determineColumnAffinity, determineColumnMetadata } from "./datatype";
 
 describe("determineColumnAffinity", () => {
   it.each([
@@ -48,6 +48,58 @@ describe("determineColumnAffinity", () => {
       const actual = determineColumnAffinity(datatype);
 
       expect(actual).toBe(expected);
+    },
+  );
+});
+
+describe("determineColumnMetadata", () => {
+  it.each([
+    // date-like declared types keep NUMERIC affinity, but their values are
+    // treated as text so Studio never coerces date strings to numbers.
+    { datatype: "DATE", expected: { affinity: "NUMERIC", group: "string" } },
+    {
+      datatype: "DATETIME",
+      expected: { affinity: "NUMERIC", group: "string" },
+    },
+    {
+      datatype: "datetime",
+      expected: { affinity: "NUMERIC", group: "string" },
+    },
+    {
+      datatype: "TIMESTAMP",
+      expected: { affinity: "NUMERIC", group: "string" },
+    },
+    { datatype: "TIME", expected: { affinity: "NUMERIC", group: "string" } },
+
+    // other NUMERIC affinity declared types stay numeric.
+    {
+      datatype: "NUMERIC",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
+    {
+      datatype: "DECIMAL(10,5)",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
+    {
+      datatype: "BOOLEAN",
+      expected: { affinity: "NUMERIC", group: "numeric" },
+    },
+
+    // non-NUMERIC affinities are untouched.
+    { datatype: "INT", expected: { affinity: "INTEGER", group: "numeric" } },
+    { datatype: "REAL", expected: { affinity: "REAL", group: "numeric" } },
+    {
+      datatype: "VARCHAR(255)",
+      expected: { affinity: "TEXT", group: "string" },
+    },
+    { datatype: "BLOB", expected: { affinity: "BLOB", group: "raw" } },
+    { datatype: null, expected: { affinity: "BLOB", group: "raw" } },
+  ])(
+    "should determine metadata for $datatype as $expected",
+    ({ datatype, expected }) => {
+      const actual = determineColumnMetadata(datatype);
+
+      expect(actual).toEqual(expected);
     },
   );
 });

--- a/data/sqlite-core/datatype.ts
+++ b/data/sqlite-core/datatype.ts
@@ -33,6 +33,35 @@ export const SQLITE_AFFINITY_TO_METADATA: Record<
 };
 
 /**
+ * Declared types like `date`, `datetime`, or `timestamp` fall through SQLite's
+ * affinity rules to NUMERIC, but their stored values are date/time strings.
+ */
+const DATE_LIKE_DECLARED_TYPE_REGEX = /DATE|TIME/;
+
+/**
+ * Resolves the affinity and Studio datatype metadata for a declared type.
+ *
+ * Date-like declared types (`date`, `datetime`, `timestamp`, ...) keep their
+ * NUMERIC affinity but are grouped as strings: their values are date/time
+ * text, and treating them as numbers would coerce edits to `NaN`.
+ */
+export function determineColumnMetadata(
+  declaredDataType: string | null,
+): Pick<DataType, "format" | "group"> & { affinity: SQLiteAffinity } {
+  const affinity = determineColumnAffinity(declaredDataType);
+
+  if (
+    affinity === "NUMERIC" &&
+    declaredDataType &&
+    DATE_LIKE_DECLARED_TYPE_REGEX.test(declaredDataType.toUpperCase())
+  ) {
+    return { affinity, group: "string" };
+  }
+
+  return { affinity, ...SQLITE_AFFINITY_TO_METADATA[affinity] };
+}
+
+/**
  * https://sqlite.org/datatype3.html#determination_of_column_affinity
  *
  * DO NOT CHANGE THE ORDER OF THE CHECKS IN THIS FUNCTION!

--- a/data/sqlite-core/datatype.ts
+++ b/data/sqlite-core/datatype.ts
@@ -35,8 +35,12 @@ export const SQLITE_AFFINITY_TO_METADATA: Record<
 /**
  * Declared types like `date`, `datetime`, or `timestamp` fall through SQLite's
  * affinity rules to NUMERIC, but their stored values are date/time strings.
+ *
+ * Only whole tokens count (`DATETIME(6)`, `TIMESTAMP WITH TIME ZONE`), so
+ * NUMERIC-affinity declared types that merely contain such a substring
+ * (`CANDIDATE`, `DATED`, `RUNTIME`) are not misclassified as date-like.
  */
-const DATE_LIKE_DECLARED_TYPE_REGEX = /DATE|TIME/;
+const DATE_LIKE_DECLARED_TYPE_REGEX = /\b(?:DATE|DATETIME|TIME|TIMESTAMP)\b/;
 
 /**
  * Resolves the affinity and Studio datatype metadata for a declared type.

--- a/data/sqlite-core/introspection.test.ts
+++ b/data/sqlite-core/introspection.test.ts
@@ -715,7 +715,7 @@ describe("sqlite-core/introspection", () => {
                       "date": {
                         "datatype": {
                           "affinity": "NUMERIC",
-                          "group": "numeric",
+                          "group": "string",
                           "isArray": false,
                           "isNative": true,
                           "name": "date",
@@ -738,7 +738,7 @@ describe("sqlite-core/introspection", () => {
                       "datetime": {
                         "datatype": {
                           "affinity": "NUMERIC",
-                          "group": "numeric",
+                          "group": "string",
                           "isArray": false,
                           "isNative": true,
                           "name": "datetime",

--- a/lib/conversionUtils.test.ts
+++ b/lib/conversionUtils.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import type { Column } from "@/data";
+
+import { coerceToValue } from "./conversionUtils";
+
+function createColumn(datatype: Partial<Column["datatype"]>): Column {
+  return {
+    datatype: {
+      group: "numeric",
+      isArray: false,
+      isNative: true,
+      name: "NUMERIC",
+      options: [],
+      schema: "main",
+      ...datatype,
+    },
+    defaultValue: null,
+    fkColumn: null,
+    fkSchema: null,
+    fkTable: null,
+    isAutoincrement: false,
+    isComputed: false,
+    isRequired: false,
+    name: "value",
+    nullable: true,
+    pkPosition: null,
+    schema: "main",
+    table: "things",
+  } as Column;
+}
+
+describe("coerceToValue", () => {
+  it("coerces numeric text to a number for numeric columns", () => {
+    const column = createColumn({ affinity: "NUMERIC" });
+
+    expect(coerceToValue(column, "=", "42.5")).toBe(42.5);
+  });
+
+  it("coerces empty input to null for numeric columns", () => {
+    const column = createColumn({ affinity: "NUMERIC" });
+
+    expect(coerceToValue(column, "=", "")).toBeNull();
+  });
+
+  it("keeps non-numeric text as-is instead of producing NaN", () => {
+    // SQLite `datetime` columns get NUMERIC affinity, but their values are
+    // date strings. Coercion must never produce NaN; non-numeric text stays
+    // text, matching SQLite's own NUMERIC affinity semantics.
+    const column = createColumn({ affinity: "NUMERIC", name: "datetime" });
+
+    expect(coerceToValue(column, "=", "2021-11-01 22:30:00")).toBe(
+      "2021-11-01 22:30:00",
+    );
+  });
+});

--- a/lib/conversionUtils.ts
+++ b/lib/conversionUtils.ts
@@ -52,7 +52,17 @@ export function coerceToValue(
   }
 
   if (dataTypeGroup === "numeric") {
-    return value === "" ? null : Number(value);
+    if (value === "") {
+      return null;
+    }
+
+    const parsed = Number(value);
+
+    // Only coerce input that actually parses as a number. Non-numeric text is
+    // kept as-is (never NaN) so e.g. date strings in SQLite NUMERIC-affinity
+    // columns survive, matching SQLite's own affinity semantics where
+    // non-numeric text is stored as TEXT.
+    return Number.isNaN(parsed) ? value : parsed;
   }
 
   return value;

--- a/ui/studio/input/NumericInput.test.tsx
+++ b/ui/studio/input/NumericInput.test.tsx
@@ -1,0 +1,156 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Column } from "@/data/adapter";
+
+import { NumericInput } from "./NumericInput";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createNumericAffinityColumn(): Column {
+  // Mirrors a SQLite column declared as e.g. `datetime`/`decimal`, which gets
+  // NUMERIC affinity and therefore the numeric input.
+  return {
+    datatype: {
+      affinity: "NUMERIC",
+      group: "numeric",
+      isArray: false,
+      isNative: true,
+      name: "decimal",
+      options: [],
+      schema: "main",
+    },
+    defaultValue: null,
+    fkColumn: null,
+    fkSchema: null,
+    fkTable: null,
+    isAutoincrement: false,
+    isComputed: false,
+    isRequired: false,
+    name: "value",
+    nullable: true,
+    pkPosition: null,
+    schema: "main",
+    table: "things",
+  } as Column;
+}
+
+function renderNumericInput(args: {
+  onSubmit: (value: unknown) => void;
+  value: unknown;
+}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <NumericInput
+        column={createNumericAffinityColumn()}
+        context="edit"
+        onSubmit={args.onSubmit}
+        readonly={false}
+        value={args.value}
+      />,
+    );
+  });
+
+  const input = container.querySelector("input");
+
+  if (!input) {
+    throw new Error("Expected numeric input element");
+  }
+
+  return {
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+    input,
+  };
+}
+
+function inputText(element: HTMLInputElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set?.bind(element);
+
+  valueSetter?.(value);
+  element.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function pressEnter(element: HTMLInputElement) {
+  element.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+    }),
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("NumericInput", () => {
+  it("submits numeric text as a number", () => {
+    const onSubmit = vi.fn();
+    const harness = renderNumericInput({ onSubmit, value: 1 });
+
+    act(() => {
+      inputText(harness.input, "42.5");
+    });
+    act(() => {
+      pressEnter(harness.input);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(42.5);
+
+    harness.cleanup();
+  });
+
+  it("submits non-numeric text as-is instead of NaN", () => {
+    // Reproduces prisma/studio#1361: typing a date-like string into a SQLite
+    // NUMERIC-affinity column must never be written as NaN.
+    const onSubmit = vi.fn();
+    const harness = renderNumericInput({
+      onSubmit,
+      value: "2021-11-01 21:30:00",
+    });
+
+    act(() => {
+      inputText(harness.input, "2021-11-01 22:30:00");
+    });
+    act(() => {
+      pressEnter(harness.input);
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("2021-11-01 22:30:00");
+
+    harness.cleanup();
+  });
+
+  it("submits the empty value when cleared", () => {
+    const onSubmit = vi.fn();
+    const harness = renderNumericInput({ onSubmit, value: 1 });
+
+    act(() => {
+      inputText(harness.input, "");
+    });
+    act(() => {
+      pressEnter(harness.input);
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith(null);
+
+    harness.cleanup();
+  });
+});

--- a/ui/studio/input/NumericInput.tsx
+++ b/ui/studio/input/NumericInput.tsx
@@ -10,7 +10,7 @@ export interface NumericInputProps {
   column: Column;
   context: "edit" | "insert";
   onNavigate?: (direction: CellEditNavigationDirection) => void;
-  onSubmit: (value: number | null | undefined) => void;
+  onSubmit: (value: number | string | null | undefined) => void;
   readonly: boolean;
   showSaveAction?: boolean;
   value: unknown;
@@ -54,7 +54,19 @@ export function NumericInput(props: NumericInputProps) {
           : currentValue;
 
       if (currentValueForComparison !== valueAsString) {
-        onSubmit(currentValue === "" ? emptyValue : Number(currentValue));
+        if (currentValue === "") {
+          onSubmit(emptyValue);
+
+          return true;
+        }
+
+        const parsed = Number(currentValue);
+
+        // Never submit NaN: non-numeric input is passed through as text. For
+        // SQLite NUMERIC-affinity columns (e.g. declared `decimal`) this
+        // matches SQLite semantics, and elsewhere the database rejects the
+        // value with a clear error instead of silently storing NaN.
+        onSubmit(Number.isNaN(parsed) ? currentValue : parsed);
 
         return true;
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
           environment: "node",
           exclude: [...configDefaults.exclude, ...localTestExcludes],
           fileParallelism: false,
-          include: ["data/**/*.test.ts"],
+          include: ["data/**/*.test.ts", "lib/**/*.test.ts"],
           name: "data",
         },
       },


### PR DESCRIPTION
Fixes #1361

## Root cause
SQLite reduces declared column types to affinities; `datetime`/`date`/`timestamp` get NUMERIC affinity, which the adapter mapped to the UI's `numeric` input group. Numeric cells then coerced input unconditionally with `Number(...)` in two places (NumericInput's save handler and `coerceToValue`'s numeric branch), so a value like `2021-11-01 22:30:00` became `NaN` and was written.

## Fix — never write NaN
1. **Introspection**: date-like declared types keep their truthful NUMERIC affinity but get input group `string`, so Studio edits/stores them as text (SQLite's own affinity conversion still applies on write).
2. **Coercion guards**: `coerceToValue` and `NumericInput` only coerce when the input actually parses as a number; otherwise the raw text passes through — matching SQLite's NUMERIC-affinity semantics where non-numeric text is stored as TEXT.

## Verification
- Tests written failing-first (the NumericInput test literally captured `NaN` being submitted), including an end-to-end update test asserting `typeof(datetime) = 'text'`.
- Full `pnpm test`: 928 tests passing; typecheck/lint clean; changeset included; staging rule documented in `Architecture/cell-editing.md`.

Note: header badges still show the NUMERIC affinity for these columns — displaying declared types is #1386's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)