### PR TITLE
chore: modernize GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: Bug report
+description: Report a bug in Prisma Studio (@prisma/studio-core)
+labels: ['kind/bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! 🙏
+
+        This repository hosts **@prisma/studio-core**, the Prisma Studio UI used by the `prisma studio` CLI command (Prisma v7+), embedded distributions, and the Prisma VS Code extension.
+
+        If your problem is with the Prisma ORM, migrations, or the CLI itself (not the Studio UI), please file it in [prisma/prisma](https://github.com/prisma/prisma/issues) instead.
+
+        💡 For questions, join our [Discord server](https://pris.ly/discord) instead of filing an issue.
+  - type: dropdown
+    id: distribution
+    attributes:
+      label: Studio distribution
+      description: How are you running Prisma Studio?
+      options:
+        - 'Prisma CLI (`prisma studio`, Prisma v7 or later)'
+        - 'Embedded (@prisma/studio-core in my own app)'
+        - 'VS Code extension (Prisma)'
+        - 'Other / not sure'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database
+      description: Which database are you connecting Studio to?
+      options:
+        - PostgreSQL
+        - MySQL / MariaDB
+        - SQLite
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: database-version
+    attributes:
+      label: Database version
+      placeholder: 'e.g. PostgreSQL 17.2'
+    validations:
+      required: true
+
+  - type: textarea
+    id: versions
+    attributes:
+      label: Prisma & studio-core versions
+      description: |
+        Run `npx prisma --version` and paste the output. If you embed Studio, also include your `@prisma/studio-core` version from `package.json`.
+      value: |
+        ```
+        // Output of `npx prisma --version`
+        ```
+        - @prisma/studio-core version (if embedded):
+    validations:
+      required: true
+
+  - type: input
+    id: os-browser
+    attributes:
+      label: Operating system & browser
+      placeholder: 'e.g. macOS 15.5, Chrome 138 / VS Code 1.102'
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Step-by-step instructions to reproduce the issue. Include relevant parts of your Prisma schema if the issue is data- or model-specific.
+
+        ⚠️ **Do NOT include database credentials!**
+      placeholder: |
+        1. Run `prisma studio`
+        2. Open the `User` model
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Screenshots are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Any relevant output from the browser console (DevTools), the terminal running `prisma studio`, or the VS Code output panel.
+      value: |
+        ```
+        // Logs here
+        ```
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
 
         If your problem is with the Prisma ORM, migrations, or the CLI itself (not the Studio UI), please file it in [prisma/prisma](https://github.com/prisma/prisma/issues) instead.
 
-        💡 For questions, join our [Discord server](https://pris.ly/discord) instead of filing an issue.
+        💡 For general usage questions, join our [Discord server](https://pris.ly/discord) instead of filing an issue.
   - type: dropdown
     id: distribution
     attributes:
@@ -53,11 +53,11 @@ body:
       label: Prisma & studio-core versions
       description: |
         Run `npx prisma --version` and paste the output. If you embed Studio, also include your `@prisma/studio-core` version from `package.json`.
-      value: |
-        ```
-        // Output of `npx prisma --version`
-        ```
-        - @prisma/studio-core version (if embedded):
+      render: shell
+      placeholder: |
+        Output of `npx prisma --version`
+
+        @prisma/studio-core version (if embedded): x.y.z
     validations:
       required: true
 
@@ -106,9 +106,9 @@ body:
       label: Logs
       description: |
         Any relevant output from the browser console (DevTools), the terminal running `prisma studio`, or the VS Code output panel.
-      value: |
-        ```
-        // Logs here
-        ```
+
+        ⚠️ **Redact secrets before posting**: connection strings, tokens, API keys, and any personal data.
+      render: shell
+      placeholder: Paste logs here (with secrets redacted)
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Prisma ORM / CLI issues
+    url: https://github.com/prisma/prisma/issues
+    about: Problems with the `prisma studio` CLI command itself, the ORM, migrations, or other server-side Prisma issues belong in the prisma/prisma repository.
+  - name: Prisma Discord
+    url: https://pris.ly/discord
+    about: Ask questions and discuss with other community members.
+  - name: Prisma documentation
+    url: https://www.prisma.io/docs
+    about: Guides and reference docs for Prisma ORM and Prisma Studio.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Problems with the `prisma studio` CLI command itself, the ORM, migrations, or other server-side Prisma issues belong in the prisma/prisma repository.
   - name: Prisma Discord
     url: https://pris.ly/discord
-    about: Ask questions and discuss with other community members.
+    about: General usage questions and community discussion. Integration/API questions about embedding @prisma/studio-core are welcome as GitHub issues.
   - name: Prisma documentation
     url: https://www.prisma.io/docs
     about: Guides and reference docs for Prisma ORM and Prisma Studio.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
+name: Feature request
+description: Suggest an improvement to Prisma Studio (@prisma/studio-core)
+labels: ['kind/feature']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        🙏 Thanks for taking the time to suggest an improvement!
+
+        Please search existing issues first to avoid duplicates. Feature requests for the Prisma ORM or CLI (rather than the Studio UI) belong in [prisma/prisma](https://github.com/prisma/prisma/issues).
+
+        💡 If your idea isn't fully formed yet, discuss it on our [Discord server](https://pris.ly/discord) first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? Describe a real situation where Prisma Studio falls short today.
+      placeholder: 'Example: When browsing a table with millions of rows, I cannot ...'
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work in Prisma Studio? A rough sketch of your ideal outcome is enough.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Workarounds you use today, or other approaches you considered.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Release process notes live in [`RELEASE.md`](RELEASE.md).
 
 ## Feedback and Contributions
 
-Open an issue for bugs, feature requests, or integration questions at [github.com/prisma/studio/issues](https://github.com/prisma/studio/issues). Clear reproduction steps, expected behavior, and screenshots make feedback much easier to act on.
+Open an issue for bugs, feature requests, or integration/API questions about embedding `@prisma/studio-core` at [github.com/prisma/studio/issues](https://github.com/prisma/studio/issues). Clear reproduction steps, expected behavior, and screenshots make feedback much easier to act on.
 
-Issue-first contributions work best for this repo. Please open an issue before investing in a large pull request; external PRs may not be the preferred path for every change. You can also join the [Prisma Discord](https://pris.ly/discord) for broader discussion.
+Issue-first contributions work best for this repo. Please open an issue before investing in a large pull request; external PRs may not be the preferred path for every change. For general usage questions and broader discussion, join the [Prisma Discord](https://pris.ly/discord).
 
 ## Security
 


### PR DESCRIPTION
Fixes #1391

The repo currently has no `.github/ISSUE_TEMPLATE` at all on main, and spam/empty issues are a recurring problem. This adds modern GitHub issue forms:

- **bug_report.yml** (`kind/bug`): required Studio distribution dropdown (CLI `prisma studio` / embedded `@prisma/studio-core` / VS Code extension), database + version, Prisma & studio-core versions, OS/browser, repro steps, expected vs actual; optional logs. Redirects ORM/CLI problems to prisma/prisma and warns against including database credentials.
- **feature_request.yml** (`kind/feature`): problem, proposed solution, optional alternatives.
- **config.yml**: `blank_issues_enabled: false` (spam mitigation) + contact links to prisma/prisma issues, the Prisma Discord, and the docs.

Tone and structure mirror prisma/prisma's issue forms, substantially leaner. No changeset — no package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)