### PR TITLE
chore: add changeset for UUID v6-v8 filter fix

### DIFF
--- a/.changeset/uuid-filter-v6-v8.md
+++ b/.changeset/uuid-filter-v6-v8.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": patch
+---
+
+Allow UUID v6–v8 values in column filters.


### PR DESCRIPTION
Follow-up to #1486 (merged without a changeset) so the fix for #1485 ships in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)