### PR TITLE
feat: add JSON export to Studio selection menu

### DIFF
--- a/.changeset/pink-llamas-unite.md
+++ b/.changeset/pink-llamas-unite.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": patch
+---
+
+Add JSON copy/save export for Studio selections

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -293,8 +293,9 @@ Paste operations map matrix values into selected writable cells, enabling spread
 
 ## Selection Export Formats
 
-When rows or cell ranges are selected, the table toolbar adds a compact `copy as` menu for exporting the current selection as Markdown or CSV.
-Exports can copy directly to the clipboard or save to disk, include column headers by default, and reuse the current grid column order and pinned-column layout so the exported shape matches what users are working with.
+When rows or cell ranges are selected, the table toolbar adds a compact `copy as` menu for exporting the current selection as Markdown, CSV, or JSON.
+Markdown and CSV exports can copy directly to the clipboard or save to disk with optional column headers, while JSON exports keep the selected visible columns as keyed objects.
+All export formats reuse the current grid column order and pinned-column layout so the exported shape matches what users are working with.
 
 ## Typed Cell Editing
 

--- a/ui/studio/views/table/ActiveTableView.filtering.test.tsx
+++ b/ui/studio/views/table/ActiveTableView.filtering.test.tsx
@@ -3134,8 +3134,10 @@ describe("ActiveTableView filtering", () => {
     expect(document.body.textContent).toContain("include column header");
     expect(document.body.textContent).toContain("copy markdown");
     expect(document.body.textContent).toContain("copy csv");
+    expect(document.body.textContent).toContain("copy json");
     expect(document.body.textContent).toContain("save markdown");
     expect(document.body.textContent).toContain("save csv");
+    expect(document.body.textContent).toContain("save json");
 
     const checkedCheckbox = findMenuCheckboxByText("include column header");
 
@@ -3151,6 +3153,354 @@ describe("ActiveTableView filtering", () => {
 
     expect(writeText).toHaveBeenCalledWith(
       "id,email\nuser_1,alice@example.com\nuser_2,bob@example.com",
+    );
+
+    view.cleanup();
+  });
+
+  it("copies row selections as json using the current visible column order", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const activeTable = {
+      columns: {
+        created_at: {
+          ...createColumn({
+            datatypeName: "timestamptz",
+            group: "datetime",
+            name: "created_at",
+          }),
+          datatype: {
+            format: "YYYY-MM-DD HH:mm:ss.SSSZZ",
+            group: "datetime",
+            isArray: false,
+            isNative: true,
+            name: "timestamptz",
+            options: [],
+            schema: "pg_catalog",
+          },
+        },
+        email: createColumn({
+          datatypeName: "character varying(64)",
+          group: "string",
+          name: "email",
+        }),
+        id: createColumn({
+          datatypeName: "uuid",
+          group: "string",
+          name: "id",
+          pkPosition: 1,
+        }),
+        is_active: createColumn({
+          datatypeName: "boolean",
+          group: "string",
+          name: "is_active",
+        }),
+        meta: createColumn({
+          datatypeName: "jsonb",
+          group: "string",
+          name: "meta",
+        }),
+        score: createColumn({
+          datatypeName: "integer",
+          group: "numeric",
+          name: "score",
+        }),
+        tags: createColumn({
+          datatypeName: "jsonb",
+          group: "string",
+          name: "tags",
+        }),
+      },
+      name: "users",
+      schema: "public",
+    };
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+    useNavigationMock.mockImplementation(() => ({
+      createUrl: vi.fn(() => "#"),
+      metadata: {
+        activeTable,
+      },
+      searchParam: navigationSearchParam,
+      setPageIndexParam: setPageIndexParamMock,
+      setSearchParam: setSearchParamMock,
+    }));
+    useIntrospectionMock.mockReturnValue({
+      data: {
+        filterOperators: [
+          "=",
+          "!=",
+          ">",
+          ">=",
+          "<",
+          "<=",
+          "is",
+          "is not",
+          "like",
+          "not like",
+          "ilike",
+          "not ilike",
+        ],
+        query: {
+          parameters: [],
+          sql: "",
+        },
+        schemas: {
+          public: {
+            name: "public",
+            tables: {
+              users: activeTable,
+            },
+          },
+        },
+        timezone: "UTC",
+      },
+      refetch: vi.fn(),
+    });
+
+    useActiveTableQueryMock.mockReturnValue({
+      data: {
+        filteredRowCount: 2,
+        rows: [
+          {
+            __ps_rowid: "row-1",
+            created_at: "2026-03-11T00:00:00.000Z",
+            email: "alice@example.com",
+            id: "user_1",
+            is_active: true,
+            meta: { owner: "alice" },
+            score: 42,
+            tags: ["vip", "beta"],
+          },
+          {
+            __ps_rowid: "row-2",
+            created_at: "2026-03-12T00:00:00.000Z",
+            email: "bob@example.com",
+            id: "user_2",
+            is_active: false,
+            meta: null,
+            score: 0,
+            tags: [],
+          },
+        ],
+      },
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+    useSelectionMock.mockReturnValue({
+      deleteSelection: vi.fn(),
+      isSelecting: true,
+      rowSelectionState: {
+        "row-2": true,
+        "row-1": true,
+      },
+      setRowSelectionState: vi.fn(),
+    });
+    gridColumnOrderState = [
+      "email",
+      "id",
+      "is_active",
+      "score",
+      "tags",
+      "meta",
+      "created_at",
+    ];
+
+    const view = renderView();
+    const copyAsTrigger = findButtonByText("copy as");
+
+    expect(copyAsTrigger).toBeDefined();
+
+    dispatchPointerClick(copyAsTrigger);
+    await flush();
+
+    const copyJsonButton = findMenuItemByText("copy json");
+
+    expect(copyJsonButton).toBeDefined();
+
+    dispatchPointerClick(copyJsonButton);
+
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify(
+        [
+          {
+            email: "alice@example.com",
+            id: "user_1",
+            is_active: true,
+            score: 42,
+            tags: ["vip", "beta"],
+            meta: { owner: "alice" },
+            created_at: "2026-03-11T00:00:00.000Z",
+          },
+          {
+            email: "bob@example.com",
+            id: "user_2",
+            is_active: false,
+            score: 0,
+            tags: [],
+            meta: null,
+            created_at: "2026-03-12T00:00:00.000Z",
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    view.cleanup();
+  });
+
+  it("copies a single selected row as one json object", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const activeTable = {
+      columns: {
+        created_at: {
+          ...createColumn({
+            datatypeName: "timestamptz",
+            group: "datetime",
+            name: "created_at",
+          }),
+          datatype: {
+            format: "YYYY-MM-DD HH:mm:ss.SSSZZ",
+            group: "datetime",
+            isArray: false,
+            isNative: true,
+            name: "timestamptz",
+            options: [],
+            schema: "pg_catalog",
+          },
+        },
+        email: createColumn({
+          datatypeName: "character varying(64)",
+          group: "string",
+          name: "email",
+        }),
+        id: createColumn({
+          datatypeName: "uuid",
+          group: "string",
+          name: "id",
+          pkPosition: 1,
+        }),
+        is_active: createColumn({
+          datatypeName: "boolean",
+          group: "string",
+          name: "is_active",
+        }),
+      },
+      name: "users",
+      schema: "public",
+    };
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+    useNavigationMock.mockImplementation(() => ({
+      createUrl: vi.fn(() => "#"),
+      metadata: {
+        activeTable,
+      },
+      searchParam: navigationSearchParam,
+      setPageIndexParam: setPageIndexParamMock,
+      setSearchParam: setSearchParamMock,
+    }));
+    useIntrospectionMock.mockReturnValue({
+      data: {
+        filterOperators: [
+          "=",
+          "!=",
+          ">",
+          ">=",
+          "<",
+          "<=",
+          "is",
+          "is not",
+          "like",
+          "not like",
+          "ilike",
+          "not ilike",
+        ],
+        query: {
+          parameters: [],
+          sql: "",
+        },
+        schemas: {
+          public: {
+            name: "public",
+            tables: {
+              users: activeTable,
+            },
+          },
+        },
+        timezone: "UTC",
+      },
+      refetch: vi.fn(),
+    });
+
+    useActiveTableQueryMock.mockReturnValue({
+      data: {
+        filteredRowCount: 2,
+        rows: [
+          {
+            __ps_rowid: "row-1",
+            created_at: "2026-03-11T00:00:00.000Z",
+            email: "alice@example.com",
+            id: "user_1",
+            is_active: true,
+          },
+          {
+            __ps_rowid: "row-2",
+            created_at: "2026-03-12T00:00:00.000Z",
+            email: "bob@example.com",
+            id: "user_2",
+            is_active: false,
+          },
+        ],
+      },
+      isFetching: false,
+      refetch: vi.fn(),
+    });
+    useSelectionMock.mockReturnValue({
+      deleteSelection: vi.fn(),
+      isSelecting: true,
+      rowSelectionState: {
+        "row-2": true,
+      },
+      setRowSelectionState: vi.fn(),
+    });
+    gridColumnOrderState = ["email", "id", "is_active", "created_at"];
+
+    const view = renderView();
+    const copyAsTrigger = findButtonByText("copy as");
+
+    expect(copyAsTrigger).toBeDefined();
+
+    dispatchPointerClick(copyAsTrigger);
+    await flush();
+
+    const copyJsonButton = findMenuItemByText("copy json");
+
+    expect(copyJsonButton).toBeDefined();
+
+    dispatchPointerClick(copyJsonButton);
+
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          email: "bob@example.com",
+          id: "user_2",
+          is_active: false,
+          created_at: "2026-03-12T00:00:00.000Z",
+        },
+        null,
+        2,
+      ),
     );
 
     view.cleanup();

--- a/ui/studio/views/table/ActiveTableView.tsx
+++ b/ui/studio/views/table/ActiveTableView.tsx
@@ -1691,12 +1691,20 @@ export function ActiveTableView(_props: ViewProps) {
                     label: "copy csv",
                   },
                   {
+                    action: () => handleCopySelectionExport("json"),
+                    label: "copy json",
+                  },
+                  {
                     action: () => handleSaveSelectionExport("markdown"),
                     label: "save markdown",
                   },
                   {
                     action: () => handleSaveSelectionExport("csv"),
                     label: "save csv",
+                  },
+                  {
+                    action: () => handleSaveSelectionExport("json"),
+                    label: "save json",
                   },
                 ].map((item) => (
                   <DropdownMenuItem

--- a/ui/studio/views/table/selection-export.test.ts
+++ b/ui/studio/views/table/selection-export.test.ts
@@ -38,7 +38,7 @@ describe("selection-export", () => {
       columnIds: ["name", "notes"],
       rows: [
         ["Acme Labs", "Line 1\nLine 2"],
-        ["Northwind Retail", '{"owner":"ops@northwind.io"}'],
+        ["Northwind Retail", { owner: "ops@northwind.io" }],
       ],
     });
   });
@@ -117,6 +117,126 @@ describe("selection-export", () => {
     ).toBe("| Acme \\| Labs | Line 1<br />Line 2 |");
   });
 
+  it("serializes json exports as an array of objects keyed by column id", () => {
+    const table = {
+      columnIds: ["id", "notes", "is_active", "tags", "score", "meta"],
+      rows: [
+        [
+          "org_acme",
+          'Value with "quotes"',
+          true,
+          ["a", "b"],
+          42,
+          { owner: "ops@acme.io" },
+        ],
+        ["org_northwind", null, false, [], 0, { owner: null }],
+      ],
+    };
+
+    expect(
+      serializeSelectionExport({
+        table,
+        format: "json",
+        includeColumnHeader: true,
+      }),
+    ).toBe(
+      JSON.stringify(
+        [
+          {
+            id: "org_acme",
+            notes: 'Value with "quotes"',
+            is_active: true,
+            tags: ["a", "b"],
+            score: 42,
+            meta: { owner: "ops@acme.io" },
+          },
+          {
+            id: "org_northwind",
+            notes: null,
+            is_active: false,
+            tags: [],
+            score: 0,
+            meta: { owner: null },
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+    expect(
+      serializeSelectionExport({
+        table,
+        format: "json",
+        includeColumnHeader: false,
+      }),
+    ).toBe(
+      JSON.stringify(
+        [
+          {
+            id: "org_acme",
+            notes: 'Value with "quotes"',
+            is_active: true,
+            tags: ["a", "b"],
+            score: 42,
+            meta: { owner: "ops@acme.io" },
+          },
+          {
+            id: "org_northwind",
+            notes: null,
+            is_active: false,
+            tags: [],
+            score: 0,
+            meta: { owner: null },
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("serializes a single-row json export as one object", () => {
+    const table = {
+      columnIds: ["id", "notes", "is_active"],
+      rows: [["org_acme", 'Value with "quotes"', true]],
+    };
+
+    expect(
+      serializeSelectionExport({
+        table,
+        format: "json",
+        includeColumnHeader: true,
+      }),
+    ).toBe(
+      JSON.stringify(
+        { id: "org_acme", notes: 'Value with "quotes"', is_active: true },
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("serializes bigint and undefined json values safely", () => {
+    const table = {
+      columnIds: ["id", "count", "optional"],
+      rows: [["org_acme", 42n, undefined]],
+    };
+
+    expect(
+      serializeSelectionExport({
+        table,
+        format: "json",
+        includeColumnHeader: true,
+      }),
+    ).toBe(
+      JSON.stringify(
+        { id: "org_acme", count: "42", optional: null },
+        null,
+        2,
+      ),
+    );
+  });
+
   it("builds stable filenames for saved exports", () => {
     expect(
       buildSelectionExportFilename({
@@ -132,6 +252,13 @@ describe("selection-export", () => {
         format: "markdown",
       }),
     ).toBe("public-users-selection.md");
+    expect(
+      buildSelectionExportFilename({
+        schema: "public",
+        table: "users",
+        format: "json",
+      }),
+    ).toBe("public-users-selection.json");
   });
 
   it("downloads the serialized export via a temporary object url", async () => {
@@ -162,6 +289,35 @@ describe("selection-export", () => {
     expect(await blobArg.text()).toBe("id,name\norg_acme,Acme Labs");
     expect(blobArg.type).toBe("text/csv;charset=utf-8");
     expect(click).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:selection-export");
+  });
+
+  it("downloads json exports with the json mime type", async () => {
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:selection-export");
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    downloadSelectionExport({
+      content: '[\n  {\n    "id": "org_acme"\n  }\n]',
+      filename: "public-users-selection.json",
+      format: "json",
+    });
+
+    const blobArg = createObjectURL.mock.calls.at(-1)?.[0];
+
+    if (!(blobArg instanceof Blob)) {
+      throw new Error("Expected selection export download to use a Blob");
+    }
+
+    expect(await blobArg.text()).toBe('[\n  {\n    "id": "org_acme"\n  }\n]');
+    expect(blobArg.type).toBe("application/json;charset=utf-8");
+    expect(click.mock.calls.length).toBeGreaterThanOrEqual(1);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:selection-export");
   });
 });

--- a/ui/studio/views/table/selection-export.test.ts
+++ b/ui/studio/views/table/selection-export.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   buildCellSelectionExportTable,
@@ -9,6 +9,10 @@ import {
 } from "./selection-export";
 
 describe("selection-export", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("builds cell selection export tables from the selected range", () => {
     expect(
       buildCellSelectionExportTable({
@@ -309,7 +313,9 @@ describe("selection-export", () => {
       format: "json",
     });
 
-    const blobArg = createObjectURL.mock.calls.at(-1)?.[0];
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+
+    const blobArg = createObjectURL.mock.calls[0]?.[0];
 
     if (!(blobArg instanceof Blob)) {
       throw new Error("Expected selection export download to use a Blob");
@@ -317,7 +323,7 @@ describe("selection-export", () => {
 
     expect(await blobArg.text()).toBe('[\n  {\n    "id": "org_acme"\n  }\n]');
     expect(blobArg.type).toBe("application/json;charset=utf-8");
-    expect(click.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(click).toHaveBeenCalledTimes(1);
     expect(revokeObjectURL).toHaveBeenCalledWith("blob:selection-export");
   });
 });

--- a/ui/studio/views/table/selection-export.ts
+++ b/ui/studio/views/table/selection-export.ts
@@ -2,11 +2,11 @@ import type { RowSelectionState } from "@tanstack/react-table";
 
 import type { GridSelectionRange } from "../../grid/cell-selection";
 
-export type SelectionExportFormat = "csv" | "markdown";
+export type SelectionExportFormat = "csv" | "json" | "markdown";
 
 export interface SelectionExportTable {
   columnIds: string[];
-  rows: string[][];
+  rows: unknown[][];
 }
 
 export function buildCellSelectionExportTable(args: {
@@ -16,7 +16,7 @@ export function buildCellSelectionExportTable(args: {
 }): SelectionExportTable {
   const { columnIds, range, rows } = args;
   const selectedColumnIds: string[] = [];
-  const selectedRows: string[][] = [];
+  const selectedRows: unknown[][] = [];
 
   for (
     let columnIndex = range.columnStart;
@@ -47,9 +47,7 @@ export function buildCellSelectionExportTable(args: {
     }
 
     selectedRows.push(
-      selectedColumnIds.map((columnId) =>
-        stringifySelectionExportValue(row[columnId]),
-      ),
+      selectedColumnIds.map((columnId) => row[columnId]),
     );
   }
 
@@ -79,9 +77,7 @@ export function buildRowSelectionExportTable(args: {
 
       return typeof rowId === "string" && rowSelectionState[rowId] === true;
     })
-    .map((row) =>
-      columnIds.map((columnId) => stringifySelectionExportValue(row[columnId])),
-    );
+    .map((row) => columnIds.map((columnId) => row[columnId]));
 
   return {
     columnIds: [...columnIds],
@@ -104,6 +100,10 @@ export function serializeSelectionExport(args: {
     return serializeSelectionExportCsv({ includeColumnHeader, table });
   }
 
+  if (format === "json") {
+    return serializeSelectionExportJson(table);
+  }
+
   return serializeSelectionExportMarkdown({ includeColumnHeader, table });
 }
 
@@ -112,7 +112,8 @@ export function buildSelectionExportFilename(args: {
   table: string;
   format: SelectionExportFormat;
 }): string {
-  const extension = args.format === "csv" ? "csv" : "md";
+  const extension =
+    args.format === "csv" ? "csv" : args.format === "json" ? "json" : "md";
 
   return `${args.schema}-${args.table}-selection.${extension}`;
 }
@@ -128,6 +129,8 @@ export function downloadSelectionExport(args: {
     type:
       format === "csv"
         ? "text/csv;charset=utf-8"
+        : format === "json"
+          ? "application/json;charset=utf-8"
         : "text/markdown;charset=utf-8",
   });
   const objectUrl = URL.createObjectURL(blob);
@@ -143,6 +146,19 @@ export function downloadSelectionExport(args: {
   URL.revokeObjectURL(objectUrl);
 }
 
+function serializeSelectionExportJson(table: SelectionExportTable): string {
+  const records = table.rows.map((row) =>
+    Object.fromEntries(
+      row.map((value, index) => [
+        table.columnIds[index],
+        normalizeSelectionExportJsonValue(value),
+      ]),
+    ),
+  );
+
+  return JSON.stringify(records.length === 1 ? records[0] : records, null, 2);
+}
+
 function serializeSelectionExportCsv(args: {
   table: SelectionExportTable;
   includeColumnHeader: boolean;
@@ -155,7 +171,7 @@ function serializeSelectionExportCsv(args: {
   }
 
   for (const row of table.rows) {
-    lines.push(serializeCsvRow(row));
+    lines.push(serializeCsvRow(row.map(stringifySelectionExportValue)));
   }
 
   return lines.join("\n");
@@ -186,7 +202,7 @@ function serializeSelectionExportMarkdown(args: {
   }
 
   for (const row of table.rows) {
-    lines.push(serializeMarkdownRow(row));
+    lines.push(serializeMarkdownRow(row.map(stringifySelectionExportValue)));
   }
 
   return lines.join("\n");
@@ -203,6 +219,35 @@ function escapeMarkdownValue(value: string): string {
     .replaceAll("\r\n", "<br />")
     .replaceAll("\n", "<br />")
     .replaceAll("\r", "<br />");
+}
+
+function normalizeSelectionExportJsonValue(value: unknown): unknown {
+  if (value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeSelectionExportJsonValue);
+  }
+
+  if (value instanceof Date) {
+    return value.toJSON();
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entryValue]) => [
+        key,
+        normalizeSelectionExportJsonValue(entryValue),
+      ]),
+    );
+  }
+
+  return value;
 }
 
 function stringifySelectionExportValue(value: unknown): string {


### PR DESCRIPTION
Closes #1560

## Summary
- add `copy json` and `save json` to the Studio selection export menu
- preserve JSON values as real JSON types instead of stringifying everything
- export a single selected row as one object instead of a one-item array

## Validation
- `pnpm typecheck`
- `pnpm test -- ui/studio/views/table/selection-export.test.ts`
- validated in local demo