### PR TITLE
feat: widen schema visualizer zoom range

### DIFF
--- a/ui/studio/views/schema/Visualiser.tsx
+++ b/ui/studio/views/schema/Visualiser.tsx
@@ -469,6 +469,8 @@ export function SchemaVisualization({
     <>
       <div className="w-full h-full bg-card">
         <ReactFlow
+          minZoom={0.05}
+          maxZoom={5}
           nodes={nodes}
           edges={initialEdges}
           onInit={(instance) => {


### PR DESCRIPTION
Closes #1568

The Schema Visualizer uses ReactFlow's default minZoom and maxZoom values, which are not enough for projects with 15-20 or more models — the available zoom range doesn't allow displaying the entire schema at once.

Setting minZoom={0.05} and maxZoom={5} widens the zoom range to fix this.