### PR TITLE
Fix launch telemetry test failing under CI

### DIFF
--- a/ui/studio/context.test.tsx
+++ b/ui/studio/context.test.tsx
@@ -26,6 +26,21 @@ vi.mock("../../checkpoint", () => ({
   check: vi.fn(() => Promise.resolve()),
 }));
 
+// std-env evaluates `isCI` once at import time from the environment, so telemetry
+// tests can't control it through process.env. Pin it here (off by default) so the
+// suite behaves the same on a developer machine and on CI.
+const stdEnvState = vi.hoisted(() => ({ isCI: false }));
+
+vi.mock("std-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("std-env")>();
+  return {
+    ...actual,
+    get isCI() {
+      return stdEnvState.isCI;
+    },
+  };
+});
+
 vi.mock("./NuqsHashAdapter", () => ({
   NuqsHashAdapter: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
@@ -192,6 +207,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   document.body.innerHTML = "";
   delete process.env.CHECKPOINT_DISABLE;
+  stdEnvState.isCI = false;
   delete (globalThis as { VERSION_INJECTED_AT_BUILD_TIME?: string })
     .VERSION_INJECTED_AT_BUILD_TIME;
 });
@@ -439,6 +455,24 @@ describe("StudioContextProvider telemetry opt-out", () => {
         product: "prisma-studio-embedded",
       }),
     );
+
+    harness.cleanup();
+  });
+
+  it("skips launch telemetry on CI", () => {
+    stdEnvState.isCI = true;
+    const harness = renderHarness();
+
+    act(() => {
+      harness.getLatestStudio()?.onEvent({
+        name: "studio_launched",
+        payload: {
+          tableCount: 3,
+        },
+      });
+    });
+
+    expect(check).not.toHaveBeenCalled();
 
     harness.cleanup();
   });


### PR DESCRIPTION
## Problem

`ui/studio/context.test.tsx › sends launch telemetry by default` fails on any CI runner.

`ui/studio/context.tsx` only sends `studio_launched` telemetry when `!isCI`. `isCI` from `std-env` is evaluated once at import time from the environment, so on a runner with `CI=true` the telemetry is (correctly) skipped and the test's expectation that `check()` was called fails. Locally the test passes because `CI` is unset. Nothing in this repo currently runs `pnpm test` on Actions, which is why it went unnoticed.

## Fix

Test-only change:

- Mock `std-env` in the test file and pin `isCI` to `false` by default via a `vi.hoisted` state object, reset in `afterEach`.
- Add a test asserting launch telemetry is **skipped** when `isCI` is `true`.

No product code changes; no changeset needed.

## Verification

- `CI=1 pnpm test` → 147 files passed, 3 skipped (MySQL suites without `STUDIO_MYSQL_TEST_URL`); previously 1 failed.
- The same file also passes with `CI` unset.
- `pnpm typecheck` and eslint clean.
