### PR TITLE
feat(demo): add OrcaRouter as a first-class demo AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
-# Optional. Set to false to hide the demo's AI UI even when an Anthropic key is present.
+# Optional. Set to false to hide the demo's AI UI even when an AI key is present.
 STUDIO_DEMO_AI_ENABLED=true
+
+# Either key enables the demo's AI flows. When both are present, OrcaRouter wins.
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+ORCAROUTER_API_KEY=your_orcarouter_api_key_here

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -24,6 +24,12 @@ The local `ppg-dev` demo can be packaged into a Compute-ready artifact instead o
 The deploy builder precompiles the browser JS/CSS, injects those assets into the bundled server, copies Prisma Dev's PGlite runtime assets into the bundle with stable filenames, and bundles the Prisma Streams worker into `touch/` so the Compute artifact can boot and keep WAL-to-stream syncing alive outside the repo checkout.
 The same demo entrypoint can also run against external development infrastructure through `pnpm demo:ppg -- --database-url <postgres-url> --streams-server-url <streams-url>`, or in streams-only mode through `pnpm demo:ppg -- --streams-server-url <streams-url>`. In those modes, Studio keeps serving the local shell and `/api/streams` proxy, but skips local Prisma Dev startup, local Streams startup, WAL wiring, and local seeding so you can point the demo at an already-running backend stack.
 
+## OrcaRouter Demo AI Provider
+
+The `ppg-dev` demo can route all Studio AI flows (table filtering, SQL generation, SQL result visualization, and Query Insights recommendations) through OrcaRouter's OpenAI-compatible endpoint by setting `ORCAROUTER_API_KEY`.
+OrcaRouter exposes a provider/model namespace across many models behind one endpoint, and when both `ANTHROPIC_API_KEY` and `ORCAROUTER_API_KEY` are present the demo prefers OrcaRouter.
+The shared `llm` hook contract is unchanged, so the rest of the demo and the embeddable Studio surface are unaffected.
+
 ## Streams-Only Studio Shell
 
 Studio can run without a database connection when a Streams server is configured, which makes it usable as a focused event-log and stream-search tool.

--- a/README.md
+++ b/README.md
@@ -592,8 +592,8 @@ pnpm demo:ppg
 
 Then open [http://localhost:4310](http://localhost:4310).
 
-To enable the demo's AI flows, copy `.env.example` to `.env` and set `ANTHROPIC_API_KEY`.
-The demo reads that key server-side and calls Anthropic Haiku 4.5 directly over HTTP through one shared `llm` hook used by table filtering, SQL generation, SQL result visualization, and Query Insights recommendations. Set `STUDIO_DEMO_AI_ENABLED=false` to hide all AI affordances without removing the key. `STUDIO_DEMO_AI_FILTERING_ENABLED` is still accepted as a legacy alias. `.env` and `.env.local` are gitignored.
+To enable the demo's AI flows, copy `.env.example` to `.env` and set `ANTHROPIC_API_KEY` or `ORCAROUTER_API_KEY` (when both are set, the demo prefers OrcaRouter).
+The demo reads the key server-side and calls the chosen provider directly over HTTP through one shared `llm` hook used by table filtering, SQL generation, SQL result visualization, and Query Insights recommendations. Set `STUDIO_DEMO_AI_ENABLED=false` to hide all AI affordances without removing the key. `STUDIO_DEMO_AI_FILTERING_ENABLED` is still accepted as a legacy alias. `.env` and `.env.local` are gitignored.
 
 The demo:
 

--- a/demo/ppg-dev/config.test.ts
+++ b/demo/ppg-dev/config.test.ts
@@ -81,6 +81,24 @@ describe("resolveDemoAiEnabled", () => {
     ).toBe(false);
   });
 
+  it("returns false when no provider key is configured", () => {
+    expect(
+      resolveDemoAiEnabled({
+        anthropicApiKey: "",
+        envValue: "true",
+        orcaRouterApiKey: "",
+      }),
+    ).toBe(false);
+  });
+
+  it("defaults to enabled when only the OrcaRouter key exists", () => {
+    expect(
+      resolveDemoAiEnabled({
+        orcaRouterApiKey: "sk-orca-test",
+      }),
+    ).toBe(true);
+  });
+
   it("defaults to enabled when the Anthropic key exists", () => {
     expect(
       resolveDemoAiEnabled({

--- a/demo/ppg-dev/config.ts
+++ b/demo/ppg-dev/config.ts
@@ -39,10 +39,15 @@ function parseOptionalBooleanEnv(
 }
 
 export function resolveDemoAiEnabled(args: {
-  anthropicApiKey: string;
+  anthropicApiKey?: string;
   envValue?: string;
+  orcaRouterApiKey?: string;
 }): boolean {
-  if (args.anthropicApiKey.trim().length === 0) {
+  const hasConfiguredProvider =
+    (args.anthropicApiKey?.trim().length ?? 0) > 0 ||
+    (args.orcaRouterApiKey?.trim().length ?? 0) > 0;
+
+  if (!hasConfiguredProvider) {
     return false;
   }
 

--- a/demo/ppg-dev/orcarouter.test.ts
+++ b/demo/ppg-dev/orcarouter.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ORCAROUTER_DEMO_MODEL,
+  ORCAROUTER_MAX_TOKENS,
+  runOrcaRouterLlmRequest,
+} from "./orcarouter";
+
+type FetchLike = (
+  ...args: Parameters<typeof fetch>
+) => ReturnType<typeof fetch>;
+
+describe("runOrcaRouterLlmRequest", () => {
+  it("calls OrcaRouter's OpenAI-compatible endpoint and returns the first text choice", async () => {
+    const fetchImplementation = vi.fn<FetchLike>(() => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: {
+                  content:
+                    '{"filters":[{"column":"email","operator":"ilike","value":"%abba%"}]}',
+                  role: "assistant",
+                },
+              },
+            ],
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+            status: 200,
+          },
+        ),
+      );
+    });
+
+    const responseText = await runOrcaRouterLlmRequest({
+      apiKey: "test-key",
+      fetchImplementation,
+      request: {
+        prompt: "Filter rows where email contains abba",
+        task: "table-filter",
+      },
+    });
+
+    expect(responseText).toContain('"column":"email"');
+    expect(fetchImplementation).toHaveBeenCalledTimes(1);
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      "https://api.orcarouter.ai/v1/chat/completions",
+      expect.any(Object),
+    );
+
+    const requestInit = fetchImplementation.mock.calls[0]?.[1];
+
+    expect(requestInit?.method).toBe("POST");
+    expect(requestInit?.body).toBe(
+      JSON.stringify({
+        max_tokens: ORCAROUTER_MAX_TOKENS,
+        messages: [
+          {
+            content: "Filter rows where email contains abba",
+            role: "user",
+          },
+        ],
+        model: ORCAROUTER_DEMO_MODEL,
+      }),
+    );
+
+    const headers = new Headers(requestInit?.headers);
+
+    expect(headers.get("authorization")).toBe("Bearer test-key");
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  it("logs request metadata without leaking the API key or prompt", async () => {
+    const fetchImplementation = vi.fn<FetchLike>(() => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                finish_reason: "stop",
+                message: {
+                  content: '{"filters":[]}',
+                  role: "assistant",
+                },
+              },
+            ],
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+            status: 200,
+          },
+        ),
+      );
+    });
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+
+    await runOrcaRouterLlmRequest({
+      apiKey: "test-key",
+      fetchImplementation,
+      request: {
+        prompt: "Filter rows where email contains abba",
+        task: "table-filter",
+      },
+    });
+
+    expect(consoleInfoSpy).toHaveBeenCalledWith("[demo][orcarouter] request", {
+      maxTokens: ORCAROUTER_MAX_TOKENS,
+      method: "POST",
+      model: ORCAROUTER_DEMO_MODEL,
+      promptLength: 37,
+      task: "table-filter",
+      url: "https://api.orcarouter.ai/v1/chat/completions",
+    });
+
+    consoleInfoSpy.mockRestore();
+  });
+
+  it("surfaces OrcaRouter API errors", async () => {
+    const fetchImplementation = vi.fn<FetchLike>(() => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "invalid api key",
+            },
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+            status: 401,
+            statusText: "Unauthorized",
+          },
+        ),
+      );
+    });
+
+    await expect(
+      runOrcaRouterLlmRequest({
+        apiKey: "bad-key",
+        fetchImplementation,
+        request: {
+          prompt: "Generate a SQL query",
+          task: "sql-generation",
+        },
+      }),
+    ).rejects.toThrow("invalid api key");
+  });
+
+  it("surfaces an explicit error when OrcaRouter hits the output token limit", async () => {
+    const fetchImplementation = vi.fn<FetchLike>(() => {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            choices: [
+              {
+                finish_reason: "length",
+                message: {
+                  content: "```json\n{",
+                  role: "assistant",
+                },
+              },
+            ],
+          }),
+          {
+            headers: {
+              "content-type": "application/json",
+            },
+            status: 200,
+          },
+        ),
+      );
+    });
+
+    await expect(
+      runOrcaRouterLlmRequest({
+        apiKey: "test-key",
+        fetchImplementation,
+        request: {
+          prompt: "Generate a chart",
+          task: "sql-visualization",
+        },
+      }),
+    ).rejects.toThrow(
+      "OrcaRouter stopped because it reached the configured output limit of 2048 tokens before finishing the response.",
+    );
+  });
+});

--- a/demo/ppg-dev/orcarouter.ts
+++ b/demo/ppg-dev/orcarouter.ts
@@ -1,0 +1,93 @@
+import {
+  buildStudioLlmOutputLimitExceededMessage,
+  type StudioLlmRequest,
+} from "../../data/llm";
+
+type FetchLike = (
+  ...args: Parameters<typeof fetch>
+) => ReturnType<typeof fetch>;
+
+export const ORCAROUTER_DEMO_MODEL = "orcarouter/auto";
+const ORCAROUTER_API_URL = "https://api.orcarouter.ai/v1/chat/completions";
+export const ORCAROUTER_MAX_TOKENS = 2048;
+
+interface OrcaRouterChatCompletionResponse {
+  choices?: Array<{
+    finish_reason?: string | null;
+    message?: {
+      content?: string | null;
+      role?: string;
+    };
+  }>;
+  error?: {
+    message?: string;
+  };
+}
+
+export class OrcaRouterOutputLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OrcaRouterOutputLimitError";
+  }
+}
+
+export async function runOrcaRouterLlmRequest(args: {
+  apiKey: string;
+  fetchImplementation?: FetchLike;
+  request: StudioLlmRequest;
+}): Promise<string> {
+  const { apiKey, fetchImplementation = fetch, request } = args;
+  const httpRequest = {
+    body: JSON.stringify({
+      max_tokens: ORCAROUTER_MAX_TOKENS,
+      messages: [
+        {
+          content: request.prompt,
+          role: "user",
+        },
+      ],
+      model: ORCAROUTER_DEMO_MODEL,
+    }),
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  } satisfies RequestInit;
+
+  console.info("[demo][orcarouter] request", {
+    maxTokens: ORCAROUTER_MAX_TOKENS,
+    method: httpRequest.method,
+    model: ORCAROUTER_DEMO_MODEL,
+    promptLength: request.prompt.length,
+    task: request.task,
+    url: ORCAROUTER_API_URL,
+  });
+
+  const response = await fetchImplementation(ORCAROUTER_API_URL, httpRequest);
+  const payload = (await response.json()) as OrcaRouterChatCompletionResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      payload.error?.message ??
+        `OrcaRouter request failed (${response.status} ${response.statusText}).`,
+    );
+  }
+
+  if (payload.choices?.[0]?.finish_reason === "length") {
+    throw new OrcaRouterOutputLimitError(
+      buildStudioLlmOutputLimitExceededMessage({
+        maxTokens: ORCAROUTER_MAX_TOKENS,
+        provider: "OrcaRouter",
+      }),
+    );
+  }
+
+  const content = payload.choices?.[0]?.message?.content;
+
+  if (!content) {
+    throw new Error("OrcaRouter response did not include any text content.");
+  }
+
+  return content;
+}

--- a/demo/ppg-dev/server.ts
+++ b/demo/ppg-dev/server.ts
@@ -16,6 +16,10 @@ import type { Query } from "../../data/query";
 import pkg from "../../package.json" with { type: "json" };
 import { AnthropicOutputLimitError, runAnthropicLlmRequest } from "./anthropic";
 import { buildDemoConfig, resolveDemoAiEnabled } from "./config";
+import {
+  OrcaRouterOutputLimitError,
+  runOrcaRouterLlmRequest,
+} from "./orcarouter";
 import { createDemoQueryInsightsStore } from "./query-insights";
 import { type DemoRuntime, startDemoRuntime } from "./runtime";
 import {
@@ -90,11 +94,13 @@ const isProduction = prebuiltAssets !== null;
 
 const APP_PORT = Number.parseInt(process.env.STUDIO_DEMO_PORT ?? "4310", 10);
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY ?? "";
+const ORCAROUTER_API_KEY = process.env.ORCAROUTER_API_KEY ?? "";
 const AI_ENABLED = resolveDemoAiEnabled({
   anthropicApiKey: ANTHROPIC_API_KEY,
   envValue:
     process.env.STUDIO_DEMO_AI_ENABLED ??
     process.env.STUDIO_DEMO_AI_FILTERING_ENABLED,
+  orcaRouterApiKey: ORCAROUTER_API_KEY,
 });
 const BOOT_ID = crypto.randomUUID();
 const STREAMS_PROXY_BASE_PATH = "/api/streams";
@@ -664,19 +670,32 @@ async function handleAiRequest(request: Request): Promise<Response> {
   }
 
   try {
-    const text = await runAnthropicLlmRequest({
-      apiKey: ANTHROPIC_API_KEY,
-      request: {
-        prompt,
-        task,
-      },
-    });
+    // When an OrcaRouter key is configured, the demo routes Studio's shared
+    // llm hook through OrcaRouter's OpenAI-compatible endpoint; otherwise it
+    // falls back to the Anthropic Messages API.
+    const text =
+      ORCAROUTER_API_KEY.trim().length > 0
+        ? await runOrcaRouterLlmRequest({
+            apiKey: ORCAROUTER_API_KEY,
+            request: {
+              prompt,
+              task,
+            },
+          })
+        : await runAnthropicLlmRequest({
+            apiKey: ANTHROPIC_API_KEY,
+            request: {
+              prompt,
+              task,
+            },
+          });
 
     return createAiSuccessResponse(text);
   } catch (error) {
     return createAiErrorResponse({
       code:
-        error instanceof AnthropicOutputLimitError
+        error instanceof AnthropicOutputLimitError ||
+        error instanceof OrcaRouterOutputLimitError
           ? "output-limit-exceeded"
           : "request-failed",
       message: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Motivation

Prisma Studio is Prisma's visual editor for exploring and editing your database, and the `ppg-dev` demo in this repo powers all of its AI-assisted flows (table filtering, SQL generation, SQL result visualization, and Query Insights recommendations) through one shared `llm` hook. Today the demo server only supports Anthropic: it reads `ANTHROPIC_API_KEY` and calls the Messages API directly.

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a first-class demo AI provider, mirroring the existing Anthropic transport in `demo/ppg-dev/anthropic.ts`. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means demo users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`demo/ppg-dev/orcarouter.ts`** — new transport that calls OrcaRouter's OpenAI-compatible `https://api.orcarouter.ai/v1/chat/completions` endpoint with the `orcarouter/auto` routing model, mirroring `runAnthropicLlmRequest`'s structure, logging behavior (no key/prompt leakage), error surfacing, and output-limit handling (`finish_reason: "length"` → `output-limit-exceeded`).
- **`demo/ppg-dev/server.ts`** — the `/api/ai` handler now prefers OrcaRouter when `ORCAROUTER_API_KEY` is set, and falls back to the Anthropic path otherwise. The `StudioLlmRequest`/`StudioLlmResponse` contract is unchanged, so the embeddable Studio surface is unaffected.
- **`demo/ppg-dev/config.ts`** — `resolveDemoAiEnabled` now treats either `ANTHROPIC_API_KEY` or `ORCAROUTER_API_KEY` as configuring the demo's AI, with the existing `STUDIO_DEMO_AI_ENABLED` override intact.
- **`demo/ppg-dev/orcarouter.test.ts`** — unit tests mirroring `anthropic.test.ts` (request shape, auth header, log sanitization, API errors, output-limit error).
- **`.env.example` / `README.md` / `FEATURES.md`** — document the new `ORCAROUTER_API_KEY` option and the preference order.

## Validation

- `pnpm typecheck` — clean.
- `pnpm lint` — 0 errors on the changed files.
- `pnpm test:demo` — 55/55 passing, including the 4 new OrcaRouter unit tests and the updated config tests.
- Live test — a temporary test wired the real `runOrcaRouterLlmRequest` to `https://api.orcarouter.ai/v1/chat/completions` with the container-injected `ORCAROUTER_API_KEY` and confirmed a successful 200 response from the `orcarouter/auto` model. (The temp test was removed before submitting.)

Feedback and contributions welcome — happy to adjust the demo transport naming or preference behavior to match Prisma's conventions.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
