### PR TITLE
feat: offer the copy as selection export in SQL view

### DIFF
--- a/.changeset/sql-result-selection-export.md
+++ b/.changeset/sql-result-selection-export.md
@@ -1,0 +1,5 @@
+---
+"@prisma/studio-core": minor
+---
+
+Offer the `copy as` selection export in SQL view. Selected result rows and cell ranges copy or save as CSV or Markdown from the SQL toolbar, using the same menu, column order and header option as the table toolbar, so query output no longer has to leave Studio one cell at a time.

--- a/Architecture/sql-view.md
+++ b/Architecture/sql-view.md
@@ -64,6 +64,7 @@ SQL result visualization is governed by:
   include client-side render/layout time.
 - The idle AI-visualization affordance MUST render on the same summary row as the `"row(s) returned in Xms"` text, right-aligned from the row-count copy.
 - SQL result rows MUST be adapted with a stable synthetic `__ps_rowid` for shared grid row identity.
+- SQL result selections MUST expose the shared selection-export menu in the view toolbar, and its selection subscription MUST live in an isolated component so selecting rows or cells never rerenders the SQL editor.
 - Result columns are dynamic and derived from query output keys.
 - SQL headers/cells MUST reuse table-view header/cell components (`DataGridHeader`, `getCell`) with synthetic column metadata.
 - Any mounted AI visualization chart for SQL results MUST live inside the shared scrollable grid header region, so it scrolls with the same container as the result rows.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -293,7 +293,8 @@ Paste operations map matrix values into selected writable cells, enabling spread
 
 ## Selection Export Formats
 
-When rows or cell ranges are selected, the table toolbar adds a compact `copy as` menu for exporting the current selection as Markdown or CSV.
+When rows or cell ranges are selected, a compact `copy as` menu appears in the view toolbar for exporting the current selection as Markdown or CSV.
+The same menu serves the table toolbar and the SQL toolbar next to the run control, so a query result leaves Studio exactly like table data instead of one cell at a time.
 Exports can copy directly to the clipboard or save to disk, include column headers by default, and reuse the current grid column order and pinned-column layout so the exported shape matches what users are working with.
 
 ## Typed Cell Editing

--- a/ui/studio/grid/SelectionExportMenu.test.tsx
+++ b/ui/studio/grid/SelectionExportMenu.test.tsx
@@ -1,0 +1,191 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SelectionExportMenu } from "./SelectionExportMenu";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ROWS = [
+  {
+    __ps_rowid: "row-1",
+    email: "alice@example.com",
+    id: "user_1",
+  },
+  {
+    __ps_rowid: "row-2",
+    email: "bob@example.com",
+    id: "user_2",
+  },
+];
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function dispatchPointerClick(element: Element | null | undefined) {
+  if (!element) {
+    return;
+  }
+
+  const PointerEventConstructor = window.PointerEvent ?? MouseEvent;
+
+  act(() => {
+    element.dispatchEvent(
+      new PointerEventConstructor("pointerdown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      }),
+    );
+    element.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      }),
+    );
+  });
+}
+
+function findButtonByText(text: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((button) => button.textContent?.trim() === text);
+}
+
+function findMenuItemByText(text: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+  ).find((item) => item.textContent?.trim() === text);
+}
+
+function renderMenu(
+  props: Partial<Parameters<typeof SelectionExportMenu>[0]> = {},
+) {
+  const container = document.createElement("div");
+
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <SelectionExportMenu
+        cellSelectionRange={null}
+        columnIds={["id", "email"]}
+        filenameBase="sql-result"
+        rows={ROWS}
+        rowSelectionState={{}}
+        {...props}
+      />,
+    );
+  });
+
+  return {
+    cleanup() {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("SelectionExportMenu", () => {
+  it("stays hidden while nothing is selected", () => {
+    const view = renderMenu();
+
+    expect(findButtonByText("copy as")).toBeUndefined();
+
+    view.cleanup();
+  });
+
+  it("copies the selected rows as csv with column headers by default", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      clipboard: { writeText },
+    });
+
+    const view = renderMenu({
+      rowSelectionState: { "row-1": true, "row-2": true },
+    });
+
+    dispatchPointerClick(findButtonByText("copy as"));
+    await flush();
+
+    dispatchPointerClick(findMenuItemByText("copy csv"));
+
+    expect(writeText).toHaveBeenCalledWith(
+      "id,email\nuser_1,alice@example.com\nuser_2,bob@example.com",
+    );
+
+    view.cleanup();
+  });
+
+  it("saves a cell range using the filename base of the host view", async () => {
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:selection-export");
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const anchors: HTMLAnchorElement[] = [];
+    const createElement = document.createElement.bind(document);
+
+    vi.spyOn(document, "createElement").mockImplementation(
+      (tagName, options) => {
+        const element = createElement(tagName, options);
+
+        if (element instanceof HTMLAnchorElement) {
+          anchors.push(element);
+        }
+
+        return element;
+      },
+    );
+
+    const view = renderMenu({
+      cellSelectionRange: {
+        columnEnd: 0,
+        columnStart: 0,
+        rowEnd: 1,
+        rowStart: 0,
+      },
+    });
+
+    dispatchPointerClick(findButtonByText("copy as"));
+    await flush();
+
+    dispatchPointerClick(findMenuItemByText("save csv"));
+
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(anchors.at(-1)?.download).toBe("sql-result-selection.csv");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:selection-export");
+
+    const blobArg = createObjectURL.mock.calls[0]?.[0];
+
+    if (!(blobArg instanceof Blob)) {
+      throw new Error("Expected selection export download to use a Blob");
+    }
+
+    expect(await blobArg.text()).toBe("id\nuser_1\nuser_2");
+
+    view.cleanup();
+  });
+});

--- a/ui/studio/grid/SelectionExportMenu.tsx
+++ b/ui/studio/grid/SelectionExportMenu.tsx
@@ -1,0 +1,199 @@
+import type { RowSelectionState } from "@tanstack/react-table";
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "../../components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu";
+import { cn } from "../../lib/utils";
+import type { GridSelectionRange } from "./cell-selection";
+import {
+  buildCellSelectionExportTable,
+  buildRowSelectionExportTable,
+  buildSelectionExportFilename,
+  downloadSelectionExport,
+  type SelectionExportFormat,
+  type SelectionExportTable,
+  serializeSelectionExport,
+} from "./selection-export";
+
+interface SelectionExportMenuProps {
+  cellSelectionRange: GridSelectionRange | null;
+  columnIds: string[];
+  filenameBase: string;
+  rows: Record<string, unknown>[];
+  rowSelectionState: RowSelectionState;
+}
+
+/**
+ * Renders the `copy as` menu for the current grid selection. Any view that
+ * renders the shared `DataGrid` can mount it, so cell ranges and row
+ * selections export the same way everywhere.
+ */
+export function SelectionExportMenu(props: SelectionExportMenuProps) {
+  const {
+    cellSelectionRange,
+    columnIds,
+    filenameBase,
+    rowSelectionState,
+    rows,
+  } = props;
+  const [isOpen, setOpen] = useState(false);
+  const [includeColumnHeader, setIncludeColumnHeader] = useState(true);
+  const selectedRowCount =
+    Object.values(rowSelectionState).filter(Boolean).length;
+
+  if (cellSelectionRange == null && selectedRowCount === 0) {
+    return null;
+  }
+
+  function buildSelectionExportTable(): SelectionExportTable | null {
+    if (cellSelectionRange) {
+      return buildCellSelectionExportTable({
+        columnIds,
+        range: cellSelectionRange,
+        rows,
+      });
+    }
+
+    if (selectedRowCount > 0) {
+      return buildRowSelectionExportTable({
+        columnIds,
+        rowSelectionState,
+        rows,
+      });
+    }
+
+    return null;
+  }
+
+  function buildSerializedSelectionExport(
+    format: SelectionExportFormat,
+  ): string {
+    const table = buildSelectionExportTable();
+
+    if (!table) {
+      return "";
+    }
+
+    return serializeSelectionExport({
+      table,
+      format,
+      includeColumnHeader,
+    });
+  }
+
+  function handleCopySelectionExport(format: SelectionExportFormat) {
+    const content = buildSerializedSelectionExport(format);
+
+    setOpen(false);
+
+    if (!content || typeof navigator.clipboard?.writeText !== "function") {
+      return;
+    }
+
+    void navigator.clipboard.writeText(content).catch((error) => {
+      console.error("Failed to copy selection export:", error);
+    });
+  }
+
+  function handleSaveSelectionExport(format: SelectionExportFormat) {
+    const content = buildSerializedSelectionExport(format);
+
+    setOpen(false);
+
+    if (!content) {
+      return;
+    }
+
+    downloadSelectionExport({
+      content,
+      filename: buildSelectionExportFilename({
+        base: filenameBase,
+        format,
+      }),
+      format,
+    });
+  }
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setOpen(open);
+
+        if (open) {
+          setIncludeColumnHeader(true);
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-expanded={isOpen}
+          aria-label="Copy selection as"
+          variant="outline"
+          className={cn(
+            "h-9 shrink-0 gap-1.5 px-3 font-sans",
+            isOpen && "bg-accent text-accent-foreground",
+          )}
+        >
+          <span>copy as</span>
+          <ChevronDown className="size-3.5 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        side="bottom"
+        className="w-[220px] max-w-[calc(100vw-2rem)] overflow-hidden p-1 font-sans"
+      >
+        <DropdownMenuCheckboxItem
+          checked={includeColumnHeader}
+          className="rounded-lg font-sans text-sm font-medium"
+          onCheckedChange={(checked) =>
+            setIncludeColumnHeader(checked === true)
+          }
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        >
+          include column header
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuSeparator />
+        <div className="p-0.5">
+          {[
+            {
+              action: () => handleCopySelectionExport("markdown"),
+              label: "copy markdown",
+            },
+            {
+              action: () => handleCopySelectionExport("csv"),
+              label: "copy csv",
+            },
+            {
+              action: () => handleSaveSelectionExport("markdown"),
+              label: "save markdown",
+            },
+            {
+              action: () => handleSaveSelectionExport("csv"),
+              label: "save csv",
+            },
+          ].map((item) => (
+            <DropdownMenuItem
+              key={item.label}
+              className="rounded-lg font-sans text-sm font-medium"
+              onSelect={item.action}
+            >
+              {item.label}
+            </DropdownMenuItem>
+          ))}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/studio/grid/selection-export.test.ts
+++ b/ui/studio/grid/selection-export.test.ts
@@ -5,6 +5,7 @@ import {
   buildRowSelectionExportTable,
   buildSelectionExportFilename,
   downloadSelectionExport,
+  getSelectionExportColumnIds,
   serializeSelectionExport,
 } from "./selection-export";
 
@@ -120,18 +121,45 @@ describe("selection-export", () => {
   it("builds stable filenames for saved exports", () => {
     expect(
       buildSelectionExportFilename({
-        schema: "public",
-        table: "users",
+        base: "public-users",
         format: "csv",
       }),
     ).toBe("public-users-selection.csv");
     expect(
       buildSelectionExportFilename({
-        schema: "public",
-        table: "users",
+        base: "public-users",
         format: "markdown",
       }),
     ).toBe("public-users-selection.md");
+    expect(
+      buildSelectionExportFilename({
+        base: "sql-result",
+        format: "csv",
+      }),
+    ).toBe("sql-result-selection.csv");
+  });
+
+  it("orders export columns by pinning then visible column order", () => {
+    expect(
+      getSelectionExportColumnIds({
+        columnOrder: ["email", "id", "created_at"],
+        columnPinning: {
+          left: ["__ps_select", "created_at"],
+          right: [],
+        },
+        defaultColumnIds: ["id", "email", "created_at"],
+      }),
+    ).toEqual(["created_at", "email", "id"]);
+  });
+
+  it("ignores column order entries that are not part of the result", () => {
+    expect(
+      getSelectionExportColumnIds({
+        columnOrder: ["dropped_column", "email"],
+        columnPinning: {},
+        defaultColumnIds: ["id", "email"],
+      }),
+    ).toEqual(["email", "id"]);
   });
 
   it("downloads the serialized export via a temporary object url", async () => {

--- a/ui/studio/grid/selection-export.test.ts
+++ b/ui/studio/grid/selection-export.test.ts
@@ -152,6 +152,19 @@ describe("selection-export", () => {
     ).toEqual(["created_at", "email", "id"]);
   });
 
+  it("keeps right-pinned columns last, as the grid renders them", () => {
+    expect(
+      getSelectionExportColumnIds({
+        columnOrder: ["id", "email", "created_at"],
+        columnPinning: {
+          left: ["__ps_select", "created_at"],
+          right: ["id"],
+        },
+        defaultColumnIds: ["id", "email", "created_at"],
+      }),
+    ).toEqual(["created_at", "email", "id"]);
+  });
+
   it("ignores column order entries that are not part of the result", () => {
     expect(
       getSelectionExportColumnIds({

--- a/ui/studio/grid/selection-export.test.ts
+++ b/ui/studio/grid/selection-export.test.ts
@@ -165,6 +165,16 @@ describe("selection-export", () => {
     ).toEqual(["created_at", "email", "id"]);
   });
 
+  it("never exports the row selection column, whatever the query returns", () => {
+    expect(
+      getSelectionExportColumnIds({
+        columnOrder: ["__ps_select", "id"],
+        columnPinning: {},
+        defaultColumnIds: ["__ps_select", "id"],
+      }),
+    ).toEqual(["id"]);
+  });
+
   it("ignores column order entries that are not part of the result", () => {
     expect(
       getSelectionExportColumnIds({

--- a/ui/studio/grid/selection-export.ts
+++ b/ui/studio/grid/selection-export.ts
@@ -128,17 +128,31 @@ export function getSelectionExportColumnIds(args: {
 }): string[] {
   const { columnOrder, columnPinning, defaultColumnIds } = args;
   const validColumnIds = new Set(defaultColumnIds);
+  const isExportableColumnId = (columnId: string) =>
+    columnId !== ROW_SELECTION_COLUMN_ID && validColumnIds.has(columnId);
+  const leftPinnedColumnIds = (columnPinning.left ?? []).filter(
+    isExportableColumnId,
+  );
+  const rightPinnedColumnIds = (columnPinning.right ?? []).filter(
+    isExportableColumnId,
+  );
+  const pinnedColumnIds = new Set([
+    ...leftPinnedColumnIds,
+    ...rightPinnedColumnIds,
+  ]);
+  // Same order as the grid renders: left-pinned, then the visible order, then
+  // right-pinned.
   const orderedColumnIds = [
     ...columnOrder.filter((columnId) => validColumnIds.has(columnId)),
     ...defaultColumnIds.filter((columnId) => !columnOrder.includes(columnId)),
-  ];
-  const pinnedColumnIds = (columnPinning.left ?? []).filter(
-    (columnId) =>
-      columnId !== ROW_SELECTION_COLUMN_ID && validColumnIds.has(columnId),
-  );
+  ].filter((columnId) => !pinnedColumnIds.has(columnId));
   const seen = new Set<string>();
 
-  return [...pinnedColumnIds, ...orderedColumnIds].filter((columnId) => {
+  return [
+    ...leftPinnedColumnIds,
+    ...orderedColumnIds,
+    ...rightPinnedColumnIds,
+  ].filter((columnId) => {
     if (seen.has(columnId)) {
       return false;
     }

--- a/ui/studio/grid/selection-export.ts
+++ b/ui/studio/grid/selection-export.ts
@@ -143,8 +143,11 @@ export function getSelectionExportColumnIds(args: {
   // Same order as the grid renders: left-pinned, then the visible order, then
   // right-pinned.
   const orderedColumnIds = [
-    ...columnOrder.filter((columnId) => validColumnIds.has(columnId)),
-    ...defaultColumnIds.filter((columnId) => !columnOrder.includes(columnId)),
+    ...columnOrder.filter(isExportableColumnId),
+    ...defaultColumnIds.filter(
+      (columnId) =>
+        isExportableColumnId(columnId) && !columnOrder.includes(columnId),
+    ),
   ].filter((columnId) => !pinnedColumnIds.has(columnId));
   const seen = new Set<string>();
 

--- a/ui/studio/grid/selection-export.ts
+++ b/ui/studio/grid/selection-export.ts
@@ -1,6 +1,11 @@
-import type { RowSelectionState } from "@tanstack/react-table";
+import type {
+  ColumnPinningState,
+  RowSelectionState,
+} from "@tanstack/react-table";
 
-import type { GridSelectionRange } from "../../grid/cell-selection";
+import type { GridSelectionRange } from "./cell-selection";
+
+const ROW_SELECTION_COLUMN_ID = "__ps_select";
 
 export type SelectionExportFormat = "csv" | "markdown";
 
@@ -108,13 +113,39 @@ export function serializeSelectionExport(args: {
 }
 
 export function buildSelectionExportFilename(args: {
-  schema: string;
-  table: string;
+  base: string;
   format: SelectionExportFormat;
 }): string {
   const extension = args.format === "csv" ? "csv" : "md";
 
-  return `${args.schema}-${args.table}-selection.${extension}`;
+  return `${args.base}-selection.${extension}`;
+}
+
+export function getSelectionExportColumnIds(args: {
+  defaultColumnIds: string[];
+  columnOrder: string[];
+  columnPinning: ColumnPinningState;
+}): string[] {
+  const { columnOrder, columnPinning, defaultColumnIds } = args;
+  const validColumnIds = new Set(defaultColumnIds);
+  const orderedColumnIds = [
+    ...columnOrder.filter((columnId) => validColumnIds.has(columnId)),
+    ...defaultColumnIds.filter((columnId) => !columnOrder.includes(columnId)),
+  ];
+  const pinnedColumnIds = (columnPinning.left ?? []).filter(
+    (columnId) =>
+      columnId !== ROW_SELECTION_COLUMN_ID && validColumnIds.has(columnId),
+  );
+  const seen = new Set<string>();
+
+  return [...pinnedColumnIds, ...orderedColumnIds].filter((columnId) => {
+    if (seen.has(columnId)) {
+      return false;
+    }
+
+    seen.add(columnId);
+    return true;
+  });
 }
 
 export function downloadSelectionExport(args: {

--- a/ui/studio/views/sql/SqlView.test.tsx
+++ b/ui/studio/views/sql/SqlView.test.tsx
@@ -386,6 +386,64 @@ async function waitFor(assertion: () => boolean): Promise<void> {
   throw new Error("Timed out waiting for SQL view state");
 }
 
+function findButtonByText(text: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((button) => button.textContent?.trim() === text);
+}
+
+function findMenuItemByText(text: string) {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+  ).find((item) => item.textContent?.trim() === text);
+}
+
+function dispatchPointerClick(element: Element | null | undefined) {
+  if (!element) {
+    return;
+  }
+
+  const PointerEventConstructor = window.PointerEvent ?? MouseEvent;
+
+  act(() => {
+    element.dispatchEvent(
+      new PointerEventConstructor("pointerdown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      }),
+    );
+    element.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, button: 0, cancelable: true }),
+    );
+  });
+}
+
+function selectResultRow(
+  container: HTMLElement,
+  rowIndex: number,
+  options?: { shiftKey?: boolean },
+) {
+  const cell = container.querySelector(
+    `td[data-grid-row-index="${rowIndex}"][data-grid-column-id="__ps_select"]`,
+  );
+
+  if (!cell) {
+    throw new Error(`Could not find row selection cell for row ${rowIndex}`);
+  }
+
+  act(() => {
+    cell.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        shiftKey: options?.shiftKey ?? false,
+      }),
+    );
+  });
+}
+
 function renderSqlView() {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -1705,6 +1763,71 @@ describe("SqlView", () => {
       expect.objectContaining({
         name: "studio_operation_success",
       }),
+    );
+
+    harness.cleanup();
+  });
+
+  it("exports selected SQL result rows through the shared copy-as menu", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+
+    const { adapter } = createAdapterMock({
+      raw: () => {
+        return Promise.resolve([
+          null,
+          {
+            query: { parameters: [], sql: "select * from users" },
+            rowCount: 2,
+            rows: [
+              { email: "alice@example.com", id: "user_1" },
+              { email: "bob@example.com", id: "user_2" },
+            ],
+          },
+        ]);
+      },
+    });
+    const studio = createStudioMock(adapter);
+    useStudioMock.mockReturnValue(studio);
+
+    const harness = renderSqlView();
+    const runButton = [...harness.container.querySelectorAll("button")].find(
+      (button) => button.textContent?.includes("Run SQL"),
+    );
+
+    if (!runButton) {
+      throw new Error("SQL view controls not rendered");
+    }
+
+    act(() => {
+      runButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitFor(() => {
+      return (
+        harness.container.textContent?.includes("2 row(s) returned") ?? false
+      );
+    });
+
+    expect(findButtonByText("copy as")).toBeUndefined();
+
+    selectResultRow(harness.container, 0);
+    selectResultRow(harness.container, 1, { shiftKey: true });
+    await flush();
+
+    dispatchPointerClick(findButtonByText("copy as"));
+    await flush();
+
+    dispatchPointerClick(findMenuItemByText("copy csv"));
+
+    expect(writeText).toHaveBeenCalledWith(
+      "email,id\nalice@example.com,user_1\nbob@example.com,user_2",
     );
 
     harness.cleanup();

--- a/ui/studio/views/sql/SqlView.tsx
+++ b/ui/studio/views/sql/SqlView.tsx
@@ -4,6 +4,7 @@ import { Prec } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import type {
   ColumnDef,
+  ColumnPinningState,
   PaginationState,
   RowSelectionState,
 } from "@tanstack/react-table";
@@ -29,6 +30,7 @@ import { TableHead, TableRow } from "../../../components/ui/table";
 import { useColumnPinning } from "../../../hooks/use-column-pinning";
 import { useIntrospection } from "../../../hooks/use-introspection";
 import { useNavigation } from "../../../hooks/use-navigation";
+import { useUiState } from "../../../hooks/use-ui-state";
 import type { CellProps } from "../../cell/Cell";
 import { Cell } from "../../cell/Cell";
 import { getCell } from "../../cell/get-cell";
@@ -36,6 +38,15 @@ import { useStudio } from "../../context";
 import { DataGrid, type DataGridProps } from "../../grid/DataGrid";
 import { DataGridDraggableHeaderCell } from "../../grid/DataGridDraggableHeaderCell";
 import { DataGridHeader } from "../../grid/DataGridHeader";
+import { getSelectionExportColumnIds } from "../../grid/selection-export";
+import {
+  getCellSelectionRange,
+  getSelectedRowIds,
+  GRID_SELECTION_MACHINE_INITIAL_STATE,
+  type GridSelectionMachineState,
+  rowIdsToRowSelectionState,
+} from "../../grid/selection-state-machine";
+import { SelectionExportMenu } from "../../grid/SelectionExportMenu";
 import { StudioHeader } from "../../StudioHeader";
 import type { ViewProps } from "../View";
 import { resolveAiSqlGeneration } from "./sql-ai-generation";
@@ -88,6 +99,11 @@ const SQL_VIEW_GRID_SCOPE = "sql:view:grid";
 const SQL_VIEW_TABLE_NAME = "__sql_result__";
 const SQL_VIEW_SCHEMA = "__sql_result__";
 const EMPTY_SQL_RESULT_ROWS: Record<string, unknown>[] = [];
+const EMPTY_SQL_RESULT_COLUMN_ORDER: string[] = [];
+const EMPTY_SQL_RESULT_COLUMN_PINNING: ColumnPinningState = {
+  left: [],
+  right: [],
+};
 const MAX_AI_SQL_VALIDATION_CORRECTIONS = 1;
 const DEFAULT_PAGINATION_STATE: PaginationState = {
   pageIndex: 0,
@@ -116,6 +132,81 @@ const SQL_ROW_SELECTION_COLUMN_DEF = {
   },
 } satisfies ColumnDef<Record<string, unknown>>;
 
+function buildSqlGridRows(resultRows: Record<string, unknown>[]): SqlGridRow[] {
+  return resultRows.map((row, index) => {
+    return {
+      ...row,
+      __ps_rowid: `sql-row-${index}`,
+    };
+  });
+}
+
+function getSqlResultColumnIds(
+  resultRows: Record<string, unknown>[],
+): string[] {
+  const ids: string[] = [];
+  const seenIds = new Set<string>();
+
+  for (const row of resultRows) {
+    for (const key of Object.keys(row)) {
+      if (seenIds.has(key)) {
+        continue;
+      }
+
+      seenIds.add(key);
+      ids.push(key);
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Owns the selection subscription so that selecting rows or cells never
+ * rerenders the SQL editor below the toolbar.
+ */
+const SqlSelectionExportMenu = memo(function SqlSelectionExportMenu(props: {
+  resultRows: Record<string, unknown>[];
+}) {
+  const { resultRows } = props;
+  const [gridSelectionState] = useUiState<GridSelectionMachineState>(
+    `datagrid:${SQL_VIEW_GRID_SCOPE}:selection-state`,
+    GRID_SELECTION_MACHINE_INITIAL_STATE,
+  );
+  const [gridColumnOrder] = useUiState<string[]>(
+    `datagrid:${SQL_VIEW_GRID_SCOPE}:column-order`,
+    EMPTY_SQL_RESULT_COLUMN_ORDER,
+  );
+  const [gridColumnPinning] = useUiState<ColumnPinningState>(
+    `datagrid:${SQL_VIEW_GRID_SCOPE}:column-pinning`,
+    EMPTY_SQL_RESULT_COLUMN_PINNING,
+  );
+  const rows = useMemo(() => buildSqlGridRows(resultRows), [resultRows]);
+  const columnIds = useMemo(
+    () =>
+      getSelectionExportColumnIds({
+        columnOrder: gridColumnOrder,
+        columnPinning: gridColumnPinning,
+        defaultColumnIds: getSqlResultColumnIds(resultRows),
+      }),
+    [gridColumnOrder, gridColumnPinning, resultRows],
+  );
+  const rowSelectionState = useMemo(
+    () => rowIdsToRowSelectionState(getSelectedRowIds(gridSelectionState)),
+    [gridSelectionState],
+  );
+
+  return (
+    <SelectionExportMenu
+      cellSelectionRange={getCellSelectionRange(gridSelectionState)}
+      columnIds={columnIds}
+      filenameBase="sql-result"
+      rows={rows}
+      rowSelectionState={rowSelectionState}
+    />
+  );
+});
+
 interface SqlResultGridProps {
   isRunning: boolean;
   paginationState: DataGridProps["paginationState"];
@@ -141,31 +232,14 @@ const SqlResultGrid = memo(function SqlResultGrid(props: SqlResultGridProps) {
     visualizationState,
   } = props;
   const resultRows = useMemo(() => result.rows, [result]);
-  const rows = useMemo<SqlGridRow[]>(() => {
-    return resultRows.map((row, index) => {
-      return {
-        ...row,
-        __ps_rowid: `sql-row-${index}`,
-      };
-    });
-  }, [resultRows]);
-  const resultColumnIds = useMemo(() => {
-    const ids: string[] = [];
-    const seenIds = new Set<string>();
-
-    for (const row of resultRows) {
-      for (const key of Object.keys(row)) {
-        if (seenIds.has(key)) {
-          continue;
-        }
-
-        seenIds.add(key);
-        ids.push(key);
-      }
-    }
-
-    return ids;
-  }, [resultRows]);
+  const rows = useMemo<SqlGridRow[]>(
+    () => buildSqlGridRows(resultRows),
+    [resultRows],
+  );
+  const resultColumnIds = useMemo(
+    () => getSqlResultColumnIds(resultRows),
+    [resultRows],
+  );
   const columnMetadataById = useMemo<Record<string, Column>>(() => {
     const metadata: Record<string, Column> = {};
 
@@ -1018,10 +1092,18 @@ export function SqlView(_props: ViewProps) {
       {isRunning ? "Cancel" : "Run SQL"}
     </Button>
   );
+  const sqlToolbarActions = (
+    <>
+      <SqlSelectionExportMenu
+        resultRows={result?.rows ?? EMPTY_SQL_RESULT_ROWS}
+      />
+      {runSqlButton}
+    </>
+  );
 
   return (
     <div className="flex flex-1 min-h-0 flex-col h-full overflow-hidden">
-      <StudioHeader endContent={runSqlButton}>
+      <StudioHeader endContent={sqlToolbarActions}>
         {hasAiSql ? (
           <div className="flex min-w-0 grow items-center gap-2">
             <Input

--- a/ui/studio/views/table/ActiveTableView.tsx
+++ b/ui/studio/views/table/ActiveTableView.tsx
@@ -1,6 +1,6 @@
 import { useIsMutating } from "@tanstack/react-query";
 import { type ColumnDef, type ColumnPinningState } from "@tanstack/react-table";
-import { ChevronDown, History, RefreshCw } from "lucide-react";
+import { History, RefreshCw } from "lucide-react";
 import {
   type Dispatch,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -31,14 +31,6 @@ import {
   AlertDialogTitle,
 } from "../../../components/ui/alert-dialog";
 import { Button, type ButtonProps } from "../../../components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "../../../components/ui/dropdown-menu";
 import { TableHead } from "../../../components/ui/table";
 import { useActiveTableInsert } from "../../../hooks/use-active-table-insert";
 import { useActiveTableQuery } from "../../../hooks/use-active-table-query";
@@ -81,6 +73,7 @@ import {
   type GridFocusedCell,
   moveFocusedCell,
 } from "../../grid/focused-cell";
+import { getSelectionExportColumnIds } from "../../grid/selection-export";
 import {
   getCellSelectionAnchor,
   getCellSelectionRange,
@@ -88,6 +81,7 @@ import {
   type GridSelectionMachineState,
   transitionGridSelectionMachine,
 } from "../../grid/selection-state-machine";
+import { SelectionExportMenu } from "../../grid/SelectionExportMenu";
 import { ExpandableSearchControl } from "../../input/ExpandableSearchControl";
 import {
   type CellEditNavigationDirection,
@@ -113,14 +107,6 @@ import {
   InlineTableFilterAddButton,
   InlineTableFiltersHeaderRow,
 } from "./InlineTableFilters";
-import {
-  buildCellSelectionExportTable,
-  buildRowSelectionExportTable,
-  buildSelectionExportFilename,
-  downloadSelectionExport,
-  type SelectionExportFormat,
-  serializeSelectionExport,
-} from "./selection-export";
 import { StagedRows } from "./StagedRows";
 import { applyAiTableFilterRequest } from "./table-ai-filter";
 import { useActiveTableRowSearch } from "./use-active-table-row-search";
@@ -376,9 +362,6 @@ export function ActiveTableView(_props: ViewProps) {
   );
   const [aiFocusRequestKey, setAiFocusRequestKey] = useState(0);
   const [gridFocusRequestId, setGridFocusRequestId] = useState(0);
-  const [isSelectionExportOpen, setSelectionExportOpen] = useState(false);
-  const [includeSelectionExportHeader, setIncludeSelectionExportHeader] =
-    useState(true);
   const [discardWiggleCount, setDiscardWiggleCount] = useState(0);
   const [isSaveDialogOpen, setSaveDialogOpen] = useState(false);
   const [isDiscardDialogOpen, setDiscardDialogOpen] = useState(false);
@@ -426,7 +409,6 @@ export function ActiveTableView(_props: ViewProps) {
       : `Open history for ${activeTable.schema}.${activeTable.name}`;
   }, [activeTable, hasPrismaWalStream, selectedRowHistoryClause]);
   const cellSelectionRange = getCellSelectionRange(gridSelectionState);
-  const hasSelectionExport = cellSelectionRange != null || selectedRowCount > 0;
   const deleteSelectionLabel = getDeleteSelectionLabel(selectedRowCount);
   const deleteConfirmationPrompt =
     getDeleteConfirmationPrompt(selectedRowCount);
@@ -563,12 +545,6 @@ export function ActiveTableView(_props: ViewProps) {
     isSaveDialogOpen,
   ]);
 
-  useEffect(() => {
-    if (!hasSelectionExport && isSelectionExportOpen) {
-      setSelectionExportOpen(false);
-    }
-  }, [hasSelectionExport, isSelectionExportOpen]);
-
   const readonly = !Object.values(activeTable?.columns ?? {}).some(
     (column) => column.pkPosition != null,
   );
@@ -639,33 +615,6 @@ export function ActiveTableView(_props: ViewProps) {
       }),
     [fallbackSelectionExportColumnIds, gridColumnOrder, gridColumnPinning],
   );
-  const selectionExportTable = useMemo(() => {
-    const exportRows = displayRows;
-
-    if (cellSelectionRange) {
-      return buildCellSelectionExportTable({
-        columnIds: selectionExportColumnIds,
-        range: cellSelectionRange,
-        rows: exportRows,
-      });
-    }
-
-    if (selectedRowCount > 0) {
-      return buildRowSelectionExportTable({
-        columnIds: selectionExportColumnIds,
-        rowSelectionState,
-        rows: exportRows,
-      });
-    }
-
-    return null;
-  }, [
-    cellSelectionRange,
-    displayRows,
-    rowSelectionState,
-    selectedRowCount,
-    selectionExportColumnIds,
-  ]);
   const editableColumnIds = useMemo(
     () => getEditableColumnIds(activeTable?.columns, readonly),
     [activeTable?.columns, readonly],
@@ -909,58 +858,6 @@ export function ActiveTableView(_props: ViewProps) {
   function confirmDeleteSelection() {
     deleteSelection();
     setDeleteDialogOpen(false);
-  }
-
-  function buildSerializedSelectionExport(
-    format: SelectionExportFormat,
-  ): string {
-    if (!selectionExportTable) {
-      return "";
-    }
-
-    return serializeSelectionExport({
-      table: selectionExportTable,
-      format,
-      includeColumnHeader: includeSelectionExportHeader,
-    });
-  }
-
-  function handleCopySelectionExport(format: SelectionExportFormat) {
-    const content = buildSerializedSelectionExport(format);
-
-    setSelectionExportOpen(false);
-
-    if (!content || typeof navigator.clipboard?.writeText !== "function") {
-      return;
-    }
-
-    void navigator.clipboard.writeText(content).catch((error) => {
-      console.error("Failed to copy selection export:", error);
-    });
-  }
-
-  function handleSaveSelectionExport(format: SelectionExportFormat) {
-    if (!activeTable) {
-      return;
-    }
-
-    const content = buildSerializedSelectionExport(format);
-
-    setSelectionExportOpen(false);
-
-    if (!content) {
-      return;
-    }
-
-    downloadSelectionExport({
-      content,
-      filename: buildSelectionExportFilename({
-        format,
-        schema: activeTable.schema,
-        table: activeTable.name,
-      }),
-      format,
-    });
   }
 
   const commandPaletteActions = useMemo(
@@ -1637,80 +1534,13 @@ export function ActiveTableView(_props: ViewProps) {
         >
           Insert row
         </Button>
-        {hasSelectionExport && (
-          <DropdownMenu
-            open={isSelectionExportOpen}
-            onOpenChange={(open) => {
-              setSelectionExportOpen(open);
-
-              if (open) {
-                setIncludeSelectionExportHeader(true);
-              }
-            }}
-          >
-            <DropdownMenuTrigger asChild>
-              <Button
-                aria-expanded={isSelectionExportOpen}
-                aria-label="Copy selection as"
-                variant="outline"
-                className={cn(
-                  "h-9 shrink-0 gap-1.5 px-3 font-sans",
-                  isSelectionExportOpen && "bg-accent text-accent-foreground",
-                )}
-              >
-                <span>copy as</span>
-                <ChevronDown className="size-3.5 text-muted-foreground" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="start"
-              side="bottom"
-              className="w-[220px] max-w-[calc(100vw-2rem)] overflow-hidden p-1 font-sans"
-            >
-              <DropdownMenuCheckboxItem
-                checked={includeSelectionExportHeader}
-                className="rounded-lg font-sans text-sm font-medium"
-                onCheckedChange={(checked) =>
-                  setIncludeSelectionExportHeader(checked === true)
-                }
-                onSelect={(event) => {
-                  event.preventDefault();
-                }}
-              >
-                include column header
-              </DropdownMenuCheckboxItem>
-              <DropdownMenuSeparator />
-              <div className="p-0.5">
-                {[
-                  {
-                    action: () => handleCopySelectionExport("markdown"),
-                    label: "copy markdown",
-                  },
-                  {
-                    action: () => handleCopySelectionExport("csv"),
-                    label: "copy csv",
-                  },
-                  {
-                    action: () => handleSaveSelectionExport("markdown"),
-                    label: "save markdown",
-                  },
-                  {
-                    action: () => handleSaveSelectionExport("csv"),
-                    label: "save csv",
-                  },
-                ].map((item) => (
-                  <DropdownMenuItem
-                    key={item.label}
-                    className="rounded-lg font-sans text-sm font-medium"
-                    onSelect={item.action}
-                  >
-                    {item.label}
-                  </DropdownMenuItem>
-                ))}
-              </div>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+        <SelectionExportMenu
+          cellSelectionRange={cellSelectionRange}
+          columnIds={selectionExportColumnIds}
+          filenameBase={`${activeTable.schema}-${activeTable.name}`}
+          rows={displayRows}
+          rowSelectionState={rowSelectionState}
+        />
         {hasStagedChanges && (
           <>
             <Button
@@ -1839,32 +1669,6 @@ function getDeleteSelectionLabel(selectedRowCount: number) {
 
 function getDeleteConfirmationPrompt(selectedRowCount: number) {
   return `Do you want to delete ${selectedRowCount} ${selectedRowCount === 1 ? "row" : "rows"}?`;
-}
-
-function getSelectionExportColumnIds(args: {
-  defaultColumnIds: string[];
-  columnOrder: string[];
-  columnPinning: ColumnPinningState;
-}) {
-  const { columnOrder, columnPinning, defaultColumnIds } = args;
-  const validColumnIds = new Set(defaultColumnIds);
-  const orderedColumnIds = [
-    ...columnOrder.filter((columnId) => validColumnIds.has(columnId)),
-    ...defaultColumnIds.filter((columnId) => !columnOrder.includes(columnId)),
-  ];
-  const pinnedColumnIds = (columnPinning.left ?? []).filter(
-    (columnId) => columnId !== "__ps_select" && validColumnIds.has(columnId),
-  );
-  const seen = new Set<string>();
-
-  return [...pinnedColumnIds, ...orderedColumnIds].filter((columnId) => {
-    if (seen.has(columnId)) {
-      return false;
-    }
-
-    seen.add(columnId);
-    return true;
-  });
 }
 
 type EditableRowKind = "insert" | "persisted";


### PR DESCRIPTION
Closes #1574

## What

SQL view gets the `copy as` selection export that table view already has. Select rows or a cell range in a query result and the toolbar, next to `Run SQL`, offers `copy markdown`, `copy csv`, `save markdown`, `save csv`, with `include column header` on by default.

Nothing new was invented: SQL results already render through the shared `DataGrid`, already carry a synthetic `__ps_rowid`, and already support both selection modes. The export logic simply lived inside `ActiveTableView` where nobody else could reach it.

## How

Two commits, the first a pure refactor:

1. `refactor: extract the selection export menu into a shared grid component`
   - `ui/studio/views/table/selection-export.ts` (+ its test) moves to `ui/studio/grid/`, next to the grid it serves. No logic change.
   - the dropdown becomes `ui/studio/grid/SelectionExportMenu.tsx`, owning its open state and its `include column header` state.
   - `getSelectionExportColumnIds()` moves out of `ActiveTableView` into the same module, so both views order exported columns identically (pinned first, then grid order).
   - `buildSelectionExportFilename()` now takes a `base` instead of `{ schema, table }`; table view passes `${schema}-${name}` and produces exactly the same filenames as before.
   - net effect on `ActiveTableView`: about 200 lines removed, no behavior change.

2. `feat: offer the copy as selection export in SQL view`
   - the menu is mounted in the SQL toolbar next to the run control, with the same outline button, labels and menu it has in table view — no variant, no host-specific styling prop.
   - its selection subscription lives in a small memoized `SqlSelectionExportMenu`, **not** in `SqlView`. This matters: reading the selection state directly in `SqlView` made the view rerender on mount and on every selection change, which the existing `focuses the SQL editor and places cursor at end on mount` test caught immediately. Keeping the subscription isolated preserves the SQL view rule that editor input and result rendering stay independent.
   - row selection is read through `getSelectedRowIds()` / `rowIdsToRowSelectionState()` as `Architecture/selection.md` requires, not from local component state.
   - saved files are named `sql-result-selection.csv` / `.md`.

## Acceptance criteria (codified in tests)

- the menu is absent while nothing is selected in SQL view;
- selecting result rows and choosing `copy csv` copies the selection with headers, in grid column order;
- a cell range saves a file named from the host view's filename base;
- table view export behavior is unchanged (existing suites still pass);
- mounting SQL view still focuses the editor exactly once.

## Testing

Run on Node 24.13.0 (`.node-version`):

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors, warning count unchanged from `main` (286)
- `pnpm test` (default projects) — 1046 passed; the single failure, `QueriesView > scopes query row counters to measured activity in the selected chart window`, fails identically on unmodified `main` here
- `STUDIO_INCLUDE_HEAVY_LOCAL_TESTS=1 pnpm vitest run ui/studio/views/table/ActiveTableView.filtering.test.tsx -t "copy-as|header inclusion|selection export"` — the four existing export tests pass
- `pnpm build` and `pnpm check:exports` — clean
- manual check in `pnpm demo:ppg`: ran `select * from organizations limit 5`, selected three rows, opened `copy as` from the toolbar, exercised `copy csv`; the menu appears only with a selection and closes on action

## Docs

- `FEATURES.md` — the `Selection Export Formats` section now covers both hosts.
- `Architecture/sql-view.md` — new rule: SQL result selections expose the shared export menu in the view toolbar, and its subscription stays isolated from the editor.
- Changeset: `minor`.

## Open question for reviewers

The trigger keeps its table-view size (`h-9`) while `Run SQL` next to it is `size="sm"` (`h-8`), so the two buttons differ by 4px in the SQL header. I kept the export button unchanged rather than introduce a size variant; happy to align either side if you prefer.

## Not in this PR

- **JSON export** (#1560). It changes `SelectionExportFormat` and deserves its own review; this PR only makes the existing formats reachable.
- **CSV formula injection.** `escapeCsvValue()` applies RFC 4180 quoting only; a value beginning with `=`, `+`, `-` or `@` is still executed as a formula when the saved file is opened in Excel or Sheets. That behavior predates this change and applies equally to table exports, so fixing it here would silently change existing exports. Happy to open a separate issue if you want it addressed.
